### PR TITLE
Equip Handler and Items typeclasses

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -15,6 +15,7 @@ own cmdsets by inheriting from them or directly from `evennia.CmdSet`.
 """
 
 from evennia import default_cmds
+from commands import equip_commands
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
     """
@@ -32,7 +33,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         #
         # any commands you add below will overload the default ones.
         #
-
+        self.add(equip_commands.EquipCmdSet())
 
 class PlayerCmdSet(default_cmds.PlayerCmdSet):
     """

--- a/commands/equip_commands.py
+++ b/commands/equip_commands.py
@@ -1,0 +1,262 @@
+#
+# Commands and cmdsetRelated to the equip handler
+#
+from evennia import CmdSet, utils
+from commands.command import Command
+
+class EquipCmdSet(CmdSet):
+
+    key = "equip_cmdset"
+    priority = 2
+
+    def at_cmdset_creation(self):
+        "Populate CmdSet"
+        self.add(CmdEquip())
+        self.add(CmdWear())
+        self.add(CmdWield())
+        self.add(CmdHold())
+        self.add(CmdRemove())
+
+class CmdEquip(Command):
+    """
+    equip
+
+    Usage:
+      equip
+
+    Show your current equipment.
+
+    """
+    key = "equip"
+    aliases = ["eq"]
+    locks = "cmd:all()"
+
+    def func(self):
+        "check equipment"
+        caller = self.caller
+        table = utils.prettytable.PrettyTable(["slot", "item"])
+        table.header = False
+        table.border = False
+        for slot, item in caller.equip:
+            if not item or not item.access(caller, 'view'):
+                continue
+            table.add_row(["{C%s{n" % slot.capitalize(), item.name.capitalize()])
+        if not str(table):
+            string = "You have nothing in your equipment."
+        else:
+            string = "{wYour equipment:\n%s" % table
+        self.caller.msg(string)
+
+class CmdWear(Command):
+    """
+    wear
+
+    Usage:
+      wear <obj>
+
+    Wear an object.
+
+    """
+    key = "wear"
+    locks = "cmd:all()"
+
+    def func(self):
+        "implements the command."
+
+        caller = self.caller
+        args = self.args.strip()
+
+        if not args:
+            caller.msg("Wear what?")
+            return
+
+        # this will search for a target
+        obj = caller.search(args)
+
+        if not obj:
+            return
+
+        if not obj in caller.contents:
+            caller.msg("You don't have %s in your inventory." % obj)
+
+        # equip primary hand with the proper command
+        if 'right hand' in utils.make_iter(obj.db.slot):
+            caller.execute_cmd("wield %s" % args)
+            return
+
+        if not obj.db.slot or 'holds' in utils.make_iter(obj.db.slot)  \
+           or not obj.access(caller, 'equip'):
+            caller.msg("You can't equip %s." % obj)
+            return
+
+        if obj in caller.equip.items():
+            caller.msg("You're already wearing %s." % obj.name)
+            return
+
+        if not caller.equip.add(obj):
+            string = "You can't equip %s." % obj
+            if [s for s in utils.make_iter(obj.db.slot) if s in caller.equip.empty_slots()]:
+                string += "You already have something there."
+            caller.msg(string)
+            return
+        # call hook
+        if hasattr(obj, "at_equip"):
+            obj.at_equip(caller)
+        caller.msg("You wear %s." % obj)
+        caller.location.msg_contents("%s wears %s." % (caller.name.capitalize(), obj),
+                                     exclude=caller)
+
+
+class CmdWield(Command):
+    """
+    wield
+
+    Usage:
+      wield <obj>
+
+    Wield an object.
+
+    """
+    key = "wield"
+    aliases = ["equip primary", "ep"]
+    locks = "cmd:all()"
+
+    def func(self):
+        "implements the command."
+        caller = self.caller
+        args = self.args.strip()
+
+        if not args:
+            caller.msg("Wield what?")
+            return
+
+        # this will search for a target
+        obj = caller.search(args)
+
+        if not obj:
+            return
+
+        if not obj in caller.contents:
+            caller.msg("You don't have %s in your inventory." % obj)
+            return
+
+        if not obj.db.slot                                         \
+           or 'right hand' not in utils.make_iter(obj.db.slot)     \
+           or not obj.access(caller, 'equip'):
+            caller.msg("You can't wield %s." % obj)
+            return
+
+        if obj in caller.equip.items():
+            caller.msg("You're already wielding %s." % obj.name)
+            return
+
+        if not caller.equip.add(obj):
+            caller.msg("You can't wield %s." % obj)
+            return
+
+        # call hook
+        if hasattr(obj, "at_equip"):
+            obj.at_equip(caller)
+
+        caller.msg("You wield %s." % obj)
+        caller.location.msg_contents("%s wields %s." % (caller.name.capitalize(), obj),
+                                     exclude=caller)
+
+class CmdHold(Command):
+    """
+    hold
+
+    Usage:
+      hold <obj>
+
+    Hold an object.
+
+    """
+    key = "hold"
+    aliases = ["equip secondary", "es"]
+    locks = "cmd:all()"
+
+    def func(self):
+        "implements the command."
+        caller = self.caller
+        args = self.args.strip()
+
+        if not args:
+            caller.msg("Hold what?")
+            return
+
+        # this will search for a target
+        obj = caller.search(args)
+
+        if not obj:
+            return
+
+        if not obj in caller.contents:
+            caller.msg("You don't have %s in your inventory." % obj)
+            return
+
+        if not obj.db.slot or not 'holds' in utils.make_iter(obj.db.slot) \
+           or not obj.access(caller, 'hold'):
+            caller.msg("You can't hold %s." % obj)
+            return
+        if obj in caller.equip.items():
+            caller.msg("You're already holding %s." % obj)
+            return
+
+        if not caller.equip.add(obj):
+            caller.msg("You can't hold %s." % obj)
+            return
+
+        # call hook
+        if hasattr(obj, "at_hold"):
+            obj.at_hold(caller)
+
+        caller.msg("You hold %s." % obj)
+        caller.location.msg_contents("%s holds %s." % (caller.name.capitalize(), obj),
+                                     exclude=caller)
+
+
+class CmdRemove(Command):
+    """
+    remove
+
+    Usage:
+      remove <obj>
+
+    Remove an object from equip.
+
+    """
+    key = "remove"
+    aliases = ["rem"]
+    locks = "cmd:all()"
+
+    def func(self):
+        "implements the command."
+
+        caller = self.caller
+        args = self.args.strip()
+
+        if not args:
+            caller.msg("Remove what?")
+            return
+
+        # this will search for a target
+        obj = caller.search(args)
+
+        if not obj:
+            return
+
+        if not obj in caller.equip.items():
+            caller.msg("You are not wearing %s." % obj)
+            return
+        if not caller.equip.remove(obj):
+            return
+
+        # call hook
+        if hasattr(obj, "at_remove"):
+            obj.at_remove(caller)
+
+        caller.msg("You remove %s." % obj)
+        caller.location.msg_contents("%s removes %s." % (caller.name.capitalize(), obj),
+                                         exclude=caller)
+

--- a/commands/equip_commands.py
+++ b/commands/equip_commands.py
@@ -96,7 +96,7 @@ class CmdWear(Command):
         if not caller.equip.add(obj):
             string = "You can't equip %s." % obj
             if [s for s in utils.make_iter(obj.db.slot) if s in caller.equip.empty_slots()]:
-                string += "You already have something there."
+                string += " You already have something there."
             caller.msg(string)
             return
         # call hook
@@ -142,6 +142,7 @@ class CmdWield(Command):
 
         if not obj.db.slot                                         \
            or 'right hand' not in utils.make_iter(obj.db.slot)     \
+           or 'left hand' not in utils.make_iter(obj.db.slot)      \
            or not obj.access(caller, 'equip'):
             caller.msg("You can't wield %s." % obj)
             return
@@ -151,7 +152,10 @@ class CmdWield(Command):
             return
 
         if not caller.equip.add(obj):
-            caller.msg("You can't wield %s." % obj)
+            string = "You can't wield %s." % obj
+            if [s for s in utils.make_iter(obj.db.slot) if s in caller.equip.empty_slots()]:
+                string += " You already have something there."
+            caller.msg(string)
             return
 
         # call hook
@@ -195,16 +199,20 @@ class CmdHold(Command):
             caller.msg("You don't have %s in your inventory." % obj)
             return
 
-        if not obj.db.slot or not 'holds' in utils.make_iter(obj.db.slot) \
-           or not obj.access(caller, 'hold'):
+        if not obj.access(caller, 'hold'):
             caller.msg("You can't hold %s." % obj)
             return
+
         if obj in caller.equip.items():
             caller.msg("You're already holding %s." % obj)
             return
 
         if not caller.equip.add(obj):
-            caller.msg("You can't hold %s." % obj)
+            string = "You can't hold %s." % obj
+            if caller.equip.get('holds'):
+                string += " You already have something there."
+            caller.msg(string)
+                
             return
 
         # call hook

--- a/commands/equip_commands.py
+++ b/commands/equip_commands.py
@@ -176,17 +176,20 @@ class CmdHold(Command):
             caller.msg("You're already holding %s." % obj)
             return
 
-        if not caller.equip.add(obj):
-            string = "You can't hold %s." % obj
-            if caller.equip.get('holds'):
-                string += " You already have something there."
-            caller.msg(string)
-                
+        if not 'holds' in caller.equip.slot:
+            caller.msg("You can't hold %s." % obj)
+            return
+
+        if caller.equip.get('holds'):
+            caller.msg("You can't hold %s. You're already holding something.")
             return
 
         # call hook
         if hasattr(obj, "at_hold"):
             obj.at_hold(caller)
+
+        # Hold command calls 'set' directly, not 'add'
+        caller.equip.set('holds', obj)
 
         caller.msg("You hold %s." % obj)
         caller.location.msg_contents("%s holds %s." % (caller.name.capitalize(), obj),

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -9,10 +9,11 @@ creation commands.
 """
 # import importlib
 from evennia import DefaultCharacter
+from evennia.utils import lazy_property
 from world.traits.trait import Trait
 
 from world import races
-
+from world.equip import EquipHandler
 
 class Character(DefaultCharacter):
 
@@ -74,6 +75,13 @@ class Character(DefaultCharacter):
             # armor
             'armor': Trait('armor', static=True)
         }
+
+    @lazy_property
+    def equip(self):
+        """
+        An handler to administrate characters equipment.
+        """
+        return EquipHandler(self)
 
     # helper method, checks if stat is valid
     def find_stat(self, stat):

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1,0 +1,124 @@
+"""
+Generic items
+"""
+from typeclasses.objects import Object
+
+class Item(Object):
+    """
+    This class implements a basic item.
+
+    """
+    def at_object_creation(self):
+        """
+        Setup item-specific variables.
+        """
+        super(Item, self).at_object_creation()
+        self.locks.add("equip:false();hold:false()")
+        if hasattr(self, 'slot'):
+            self.db.slot = self.slot
+
+    def at_equip(self, character):
+        """
+        Hook called when an object is equipped by character.
+
+        Args:
+            character - the character equipping this object
+
+        """
+        pass
+
+    def at_hold(self, character):
+        """
+        Hook called when a character holds this object.
+
+        Args:
+            character - the character holding this object
+
+        """
+        pass
+
+    def at_remove(self, character):
+        """
+        Hook called when an object is removed from character equip.
+        
+        Args:
+            character - the character removing this object
+
+        """
+        pass
+
+class Armor(Item):
+    """
+    This class implements a basic armor object
+
+    """
+    armor_type = 'other'
+
+    def at_object_creation(self):
+        """
+        Setup weapon-specific variables.
+        """
+        super(Armor, self).at_object_creation()
+        self.locks.add("equip:all()")
+        self.tags.add(self.armor_type, category='armor')
+
+class Weapon(Item):
+    """
+    This class implements a basic weapon object
+
+    """
+    weapon_type = 'other'
+    slot = 'right hand'
+
+    def at_object_creation(self):
+        """
+        Setup weapon-specific variables.
+        """
+        super(Weapons, self).at_object_creation()
+        self.locks.add("equip:all()")
+        self.tags.add(self.weapon_type, category='weapon')
+
+class Shield(Armor):
+    """
+    This class implements a basic shield object,
+    a functional type of armor.
+
+    """
+    armor_type = 'shield'
+    slot = 'left hand'
+
+class MeleeWeapon(Weapon):
+    """
+    This class implements a basic melee weapon
+
+    """
+    pass
+
+class RangedWeapon(Weapon):
+    """
+    This class implements a basic ranged weapon
+
+    """
+    pass
+
+class Dagger(MeleeWeapon):
+    """
+    This class implements a basic dagger object
+
+    """
+    weapon_type = 'dagger'
+
+class Sword(MeleeWeapon):
+    """
+    This class implements a basic sword object
+
+    """
+    weapon_type = 'sword'
+
+class Bow(RangedWeapon):
+    """
+    This class implements a basic sword object
+
+    """
+    weapon_type = 'bow'
+

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -14,7 +14,32 @@ class Item(Object):
         """
         super(Item, self).at_object_creation()
         self.locks.add("equip:false();hold:false()")
-        if hasattr(self, 'slot'):
+
+    def at_hold(self, character):
+        """
+        Hook called when a character holds this object.
+
+        Args:
+            character - the character holding this object
+
+        """
+        pass
+
+
+class EquippableItem(Item):
+    """
+    This class implements an item that can be set in the equipment.
+
+    """
+    slot = None
+
+    def at_object_creation(self):
+        """
+        Setup item-specific variables.
+        """
+        super(EquippableItem, self).at_object_creation()
+        self.locks.add("equip:all()")
+        if hasattr(self, 'slot') and self.slot:
             self.db.slot = self.slot
 
     def at_equip(self, character):
@@ -23,16 +48,6 @@ class Item(Object):
 
         Args:
             character - the character equipping this object
-
-        """
-        pass
-
-    def at_hold(self, character):
-        """
-        Hook called when a character holds this object.
-
-        Args:
-            character - the character holding this object
 
         """
         pass
@@ -47,7 +62,7 @@ class Item(Object):
         """
         pass
 
-class Armor(Item):
+class Armor(EquippableItem):
     """
     This class implements a basic armor object
 
@@ -62,7 +77,7 @@ class Armor(Item):
         self.locks.add("equip:all()")
         self.tags.add(self.armor_type, category='armor')
 
-class Weapon(Item):
+class Weapon(EquippableItem):
     """
     This class implements a basic weapon object
 

--- a/world/equip.py
+++ b/world/equip.py
@@ -58,8 +58,6 @@ class EquipHandler(object):
         items():            returns a list of equipped items. Does not
                             returns unoccupied slots
         empty_slots():      returns a list of empty slots
-        showtable():        returns a formatted table of paired
-                            slot, equip. Useful for printing equipment
 
     Example usage:
         Say obj is a hat.
@@ -172,18 +170,6 @@ class EquipHandler(object):
         """
         return filter(lambda x: self.obj.db.equip[x] is None, \
                       self.obj.db.equip.keys())
-
-    def showtable(self):
-        """
-        Shows the equip as a nice formatted table.
-        """
-        table = utils.prettytable.PrettyTable(["slot", "item"])
-        table.header = False
-        table.border = False
-        for slot, item in self:
-            if item:
-                table.add_row(["{C%s{n" % slot.capitalize(), item.name])
-        return str(table).strip()
 
     def add(self, obj):
         """ 

--- a/world/equip.py
+++ b/world/equip.py
@@ -111,8 +111,7 @@ class EquipHandler(object):
             # At the same time all expected errors are converted
             # to KeyError
             try:
-                if slot not in self.slots                           \
-                   or slot not in utils.make_iter(item.db.slot):
+                if slot not in self.slots:
                     raise TypeError
             except TypeError:
                 raise KeyError("Slot not available: %s" % slot)
@@ -183,6 +182,11 @@ class EquipHandler(object):
         self._set(slot, obj)
         return True
 
+    def hold(self, obj):
+        """ 
+        Add an object to the 'hold' slot of character's equip.
+        """
+        
     def remove(self, obj):
         """ 
         Remove an object from character's equip.

--- a/world/equip.py
+++ b/world/equip.py
@@ -1,0 +1,211 @@
+# -*- coding: UTF-8 -*-
+from evennia import settings, utils
+ 
+DEFAULT = ('head',
+           'left ear',
+           'right ear',
+           'body',
+           'left hand',
+           'right hand',
+           'holds')
+
+class EquipHandler(object):
+    """
+    Simple handler for characters equipment.
+    This is actually an interface to easily read, write and manage
+    the equipment of a character. Slots/objects can be accessed by
+    getter and setter methods.
+    Add and remove methods are also present, they add a little bit
+    of error checking to the set method.
+    The handler can also check for the presence of an item in the equip
+    with the simple syntax `obj in char.equip` and it is iterable.
+    To implement it add it to the main character
+    typeclass as a property:
+    
+    `
+    from world.equip import EquipHandler
+    
+    @property
+    def equip(self):
+        return EquipHandler(self, list_of_slots)
+    `
+    
+    list_of_slots is a list or a tuple of named slots
+    
+    Also see commands/equip_commands.py for the commands
+    related to this handler.
+
+
+    EquipHandler attributes:
+    
+        obj:    the parent typeclass
+        slots:  a tuple of slots available for the character
+
+    EquipHandler methods:
+        add(item):          add an item to the equipment, returns True
+                            if the item is successfully equipped
+        remove(item)        remove an item from the equipment, returns
+                            True if the item is correctly removed.
+        get(slot):          returns the item in the corresponding slot,
+                            if present, otherwise returns None
+        set(slot, item):    set an item in the corresponding slot,
+                            raise ValueError if the item can't be set
+                            in equip, raise KeyError if slot is not
+                            already defined in equip. This set method
+                            replace objects in equipment, use the remove
+                            method to correctly handle real-life
+                            situations
+        items():            returns a list of equipped items. Does not
+                            returns unoccupied slots
+        empty_slots():      returns a list of empty slots
+        showtable():        returns a formatted table of paired
+                            slot, equip. Useful for printing equipment
+
+    Example usage:
+        Say obj is a hat.
+        > obj in character.equip
+        False
+        > character.equip.add(obj)
+        True
+        > obj in equip
+        True
+        > for slot, item in character.equip:
+        >     print "%s: %s" % (slot, item)
+        head: a hat
+        > character.equip.remove(obj)
+        True
+        
+
+    """
+    def __init__(self, obj, slots=DEFAULT):
+        """
+        Init class.
+        """
+        # save the parent typeclass
+        self.obj = obj
+        # available slots
+        self.slots = tuple(set(slots))
+        # initialize equipment
+        if not self.obj.db.equip:
+            self.obj.db.equip = {x: None for x in self.slots}
+
+    def _set(self, slot, item):
+        """
+        set an item in the corresponding slot, raise ValueError if the
+        item can't be set in equip, raise KeyError if slot is not already
+        defined in equip. This set method replace objects in equipment,
+        use the remove method to correctly handle real-life situations.
+        """
+        # allows None values to pass all checks
+        if item != None:
+            # first check, only allows typeclasses to pass;
+            # at the same time all expected errors are converted
+            # to ValueError
+            try:
+                if not item.is_typeclass(settings.BASE_OBJECT_TYPECLASS,
+                                         exact=False):
+                    raise AttributeError
+            except AttributeError:
+                raise ValueError("Item can't be set in equip.")
+            # second check, only allows objects that are
+            # correctly defined to be equipped, i.e. they have a slot
+            # and that slot exist in the current equip.
+            # At the same time all expected errors are converted
+            # to KeyError
+            try:
+                if slot not in self.slots                           \
+                   or slot not in utils.make_iter(item.db.slot):
+                    raise TypeError
+            except TypeError:
+                raise KeyError("Slot not available: %s" % slot)
+        self.obj.db.equip[slot] = item
+
+    # implement the set method
+    set = _set
+
+    def _get(self, slot, default=None):
+        """
+        Getter method. Returns the item in the corresponding slot,
+        if present, otherwise returns `default`
+        """
+        return self.obj.db.equip.get(slot, default)
+
+    # implement the get method
+    get = _get
+
+    def __len__(self):
+        """
+        Returns the number of equipped objects.
+        """
+        return len(self.items())
+
+    def __str__(self):
+        """
+        Shows the equipment.
+        """
+        return str(self.showtable())
+
+    def __iter__(self):
+        """
+        Iterate over the equip in an ordered way.
+        """
+        if not self.slots:
+            return
+        for slot in self.slots:
+                yield (slot, self.obj.db.equip.get(slot))
+
+    def __contains__(self, item):
+        """
+        Implement the __contains__ method.
+        """
+        return item in self.items()
+
+    def items(self):
+        """
+        Shows equipped items.
+        """
+        return filter(None, self.obj.db.equip.values())
+
+    def empty_slots(self):
+        """
+        Returns empty slots.
+        """
+        return filter(lambda x: self.obj.db.equip[x] is None, \
+                      self.obj.db.equip.keys())
+
+    def showtable(self):
+        """
+        Shows the equip as a nice formatted table.
+        """
+        table = utils.prettytable.PrettyTable(["slot", "item"])
+        table.header = False
+        table.border = False
+        for slot, item in self:
+            if item:
+                table.add_row(["{C%s{n" % slot.capitalize(), item.name])
+        return str(table).strip()
+
+    def add(self, obj):
+        """ 
+        Add an object to character's equip.
+        """
+        slots = utils.make_iter(obj.db.slot)
+        free_slots = [sl for sl in slots if self.get(sl, True) == None]
+        if not free_slots:
+            return False
+        slot = free_slots[0]
+        self._set(slot, obj)
+        return True
+
+    def remove(self, obj):
+        """ 
+        Remove an object from character's equip.
+        """
+        for slot, item in self:
+            if item == obj:
+                self._set(slot, None)
+                return True
+        return False
+
+
+


### PR DESCRIPTION
@ergodicbreak 
- Wear and Wield commands functionalities are now merged.
- I reworked the Hold command a little bit, now the lock access type 'hold' is a fully functional part: if the lock is passed, the object can be holded, no other attribute check required.
- I've created a new typeclass between base item and weapons/armors, and called it EquippableItem (please suggest a better name!), hooks at_equip and at_remove are now on this typeclass.
- the above point is dangerous since is splitting the typeclass tree in two parts (equippable, not equippable) and can lead to problems if not managed correctly. It is also killing 'duck typing', I don't know if this is a priority in the project. Equip commands are checking the presence of hooks before calling it, though, so we shouldn't have problems with them.
- applied grammar corrections to strings
- 'left hand', 'right hand' and 'holds' slots are still hardcoded in commands functionalities.
