### PR TITLE
New description for Limbo

### DIFF
--- a/server/conf/at_initial_setup.py
+++ b/server/conf/at_initial_setup.py
@@ -26,14 +26,14 @@ def at_initial_setup():
         {YDeveloper/Builder Resources{n
           * Issue tracking: https://github.com/evennia/ainneve/issues
           * Discussion list: https://groups.google.com/forum/?fromgroups#!categories/evennia/ainneve
-          * Annieve Wiki: https://github.com/evennia/ainneve/wiki
+          * Ainneve Wiki: https://github.com/evennia/ainneve/wiki
           * Evennia Developer IRC: http://webchat.freenode.net/?channels=evennia
 
         {YGetting Started{n
           As Player #1 you can use the {w@batchcmd{n or {w@batchcode{n commands to
           build components of Ainneve, or the entire world (once it has been created).
 
-          Build scripts are in the {wworld/content/{n directory and have {w*.ev{n or {w*.py{n extensions.
+          Build scripts are in the {wworld/build/{n directory and have {w*.ev{n or {w*.py{n extensions.
 
         """)
 

--- a/server/conf/at_initial_setup.py
+++ b/server/conf/at_initial_setup.py
@@ -14,6 +14,26 @@ does what you expect it to.
 
 """
 
+from evennia.utils import search, dedent
 
 def at_initial_setup():
-    pass
+    limbo = search.objects('Limbo')[0]
+    limbo.db.desc = dedent("""
+        Welcome to {mAinneve{n, the example game for Evennia!
+
+        The project is still in early development, and we welcome your contributions.
+
+        {YDeveloper/Builder Resources{n
+          * Issue tracking: https://github.com/evennia/ainneve/issues
+          * Discussion list: https://groups.google.com/forum/?fromgroups#!categories/evennia/ainneve
+          * Annieve Wiki: https://github.com/evennia/ainneve/wiki
+          * Evennia Developer IRC: http://webchat.freenode.net/?channels=evennia
+
+        {YGetting Started{n
+          As Player #1 you can use the {w@batchcmd{n or {w@batchcode{n commands to
+          build components of Ainneve, or the entire world (once it has been created).
+
+          Build scripts are in the {wworld/content/{n directory and have {w*.ev{n or {w*.py{n extensions.
+
+        """)
+

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -34,6 +34,7 @@ HTTP_LOG_FILE = os.path.join(LOG_DIR, 'http_requests.log')
 
 # Other defaults
 PROTOTYPE_MODULES = ("world.prototypes",)
+BASE_BATCHPROCESS_PATHS = ['world.build']
 
 ######################################################################
 # Evennia Database config


### PR DESCRIPTION
This is a purely cosmetic change, related to the discussion in issue #39. 

As mentioned in that issue, there is a separate pull request that will effectively fix the error that is described. However, with the default Limbo room description, the command to build the tutorial world is still front and center. I went ahead and created a new, Ainneve-specific description for Limbo that brings together some dev resources from the web and gives minimal instructions on where to find build scripts. I made the assumption that batch creation scripts would live in `world/content/`, but since there are currently no build scripts in the master, I wasn't sure whether we were intending them to be there, or just in `world/`. I'm open to whatever edits are desired. 

Note: If you want to see this description in action, you should be sure to pull the most recent Evennia core code, as there was a bug in the text2html parser that was rendering the links incorrectly. I submitted a fix and it was merged yesterday.
