### PR TITLE
Converted the TraitFactory class to TraitHandler

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -13,7 +13,7 @@ from evennia.utils import lazy_property
 
 from objects import Object
 from world.equip import EquipHandler
-from world.traits import TraitFactory
+from world.traits import TraitHandler
 from world.economy import GC, SC, CC
 
 
@@ -135,15 +135,15 @@ class Character(Object):
         # Non-persistent attributes
         self.ndb.group = None
 
-    @property
+    @lazy_property
     def traits(self):
-        """TraitFactory that manages character traits."""
-        return TraitFactory(self.db.traits)
+        """TraitHandler that manages character traits."""
+        return TraitHandler(self)
 
-    @property
+    @lazy_property
     def skills(self):
-        """TraitFactory that manages character traits."""
-        return TraitFactory(self.db.skills)
+        """TraitHandler that manages character traits."""
+        return TraitHandler(self, db_attribute='skills')
 
     @lazy_property
     def equip(self):

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -125,8 +125,6 @@ class Character(Object):
         self.db.race = None
         self.db.focus = None
         self.db.archetype = None
-        self.db.traits = {}       # trait data
-        self.db.skills = {}       # skills data
         self.db.slots = {}        # equipment slots
         self.db.limbs = ()        # limb/slot mappings
 

--- a/world/skills.py
+++ b/world/skills.py
@@ -170,13 +170,15 @@ def apply_skills(char):
     Args:
         char (Character): the character being initialized
     """
-    char.db.skills = \
-        {skill: {'type': 'trait',
-                 'base': char.traits[data['base']].actual,
-                 'mod': 0,
-                 'name': data['name'],
-                 'extra': {'plus': 0, 'minus': 0}}
-            for skill, data in _SKILL_DATA.iteritems()}
+    for skill, data in _SKILL_DATA.iteritems():
+        char.skills.add(
+            key=skill,
+            type='static',
+            base=char.traits[data['base']].actual,
+            mod=0,
+            name=data['name'],
+            extra=dict(plus=0, minus=0)
+        )
 
 
 def load_skill(skill):
@@ -199,7 +201,7 @@ def validate_skills(char):
     """Validates a player's skill allocations during chargen.
 
     Args:
-        char (Character): character with populated skills TraitFactory
+        char (Character): character with populated skills TraitHandler
 
     Returns:
         (tuple[bool, str]): first value is whether the skills are valid,
@@ -218,7 +220,7 @@ def finalize_skills(skills):
     """Sets/calculates the permanent skill values at the end of chargen.
 
     Args:
-        skills (TraitFactory): validated skills TraitFactory collection
+        skills (TraitHandler): validated skills TraitHandler collection
 
     Note:
         During chargen, penalty counters are applied to the `base`


### PR DESCRIPTION
This PR addresses Issue #54.

Implemented methods of Evennia handler interface: `add`, `get`, `remove`, `clear`, and `all` as a property returning a list of the trait keys held by the handler.

Updated character typeclass, and archetypes and skills modules accordingly.
Updated docs and added tests for new `TraitHandler` functions.

@Griatch: I went with a string argument for the storage key on the handler's constructor, rather than hard coding it in a subclass, since the value of the key and the name of the enclosing property function are the only differences between a "traits" TraitHandler and a "skills" TraitHandler. 
