### PR TITLE
Items fixes

### DIFF
--- a/commands/equip.py
+++ b/commands/equip.py
@@ -2,6 +2,7 @@
 Item and equipment-related command module.
 """
 from evennia import CmdSet
+from evennia.utils import fill
 from commands.command import Command, MuxCommand
 from evennia.utils.evtable import EvTable, fill
 from typeclasses.weapons import Weapon
@@ -50,13 +51,13 @@ class CmdInventory(MuxCommand):
             for item in items:
                 data[0].append("|C{}|n".format(item.name))
                 data[1].append(fill(item.db.desc or "", 50))
-                stat = ""
-                if item.db.damage:
+                stat = " "
+                if item.attributes.has('damage'):
                     stat += "(|rDamage: {:>2d}|n) ".format(item.db.damage)
-                if item.db.range:
+                if item.attributes.has('range'):
                     stat += "(|GRange: {:>2d}|n) ".format(item.db.range)
-                if item.db.toughness:
-                    stat += "(|yToughness: {:>2d}|n) ".format(item.db.toughness)
+                if item.attributes.has('toughness'):
+                    stat += "(|yToughness: {:>2d}|n)".format(item.db.toughness)
                 data[2].append(stat)
             table = EvTable(header=False, table=data, border=None, valign='t')
             string = "|YYou are carrying:|n\n{}".format(table)
@@ -165,13 +166,13 @@ class CmdEquip(MuxCommand):
             for slot, item in caller.equip:
                 if not item or not item.access(caller, 'view'):
                     continue
-                stat = ""
-                if item.db.damage:
+                stat = " "
+                if item.attributes.has('damage'):
                     stat += "(|rDamage: {:>2d}|n) ".format(item.db.damage)
-                if item.db.range:
+                if item.attributes.has('range'):
                     stat += "(|GRange: {:>2d}|n) ".format(item.db.range)
-                if item.db.toughness:
-                    stat += "(|yToughness: {:>2d}|n) ".format(item.db.toughness)
+                if item.attributes.has('toughness'):
+                    stat += "(|yToughness: {:>2d}|n)".format(item.db.toughness)
 
                 data.append(
                     "  |b{slot:>{swidth}.{swidth}}|n: {item:<20.20} {stat}".format(

--- a/commands/equip.py
+++ b/commands/equip.py
@@ -2,8 +2,7 @@
 Item and equipment-related command module.
 """
 from evennia import CmdSet
-from evennia.utils import fill
-from commands.command import Command, MuxCommand
+from commands.command import MuxCommand
 from evennia.utils.evtable import EvTable, fill
 from typeclasses.weapons import Weapon
 from typeclasses.armors import Armor, Shield

--- a/typeclasses/weapons.py
+++ b/typeclasses/weapons.py
@@ -60,7 +60,7 @@ class TwoHanded(object):
     handedness = 2
 
 
-class TwoHandedWeapon(Weapon, TwoHanded):
+class TwoHandedWeapon(TwoHanded, Weapon):
     """Typeclass for two-handed melee weapons."""
     pass
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,6 +1,7 @@
 """
 Utility objects.
 """
+from evennia import TICKER_HANDLER as tickerhandler
 from world import archetypes, races, skills
 
 
@@ -22,7 +23,10 @@ def sample_char(char, archetype, race, focus=None):
     char.traits.CHA.base += 1
     char.traits.VIT.base += 2
     char.traits.MAG.base += 2
-    archetypes.calculate_secondary_traits(char.traits)
     focus = focus or races.load_race(race).foci[0]
     races.apply_race(char, race, focus)
+    archetypes.calculate_secondary_traits(char.traits)
+    archetypes.finalize_traits(char.traits)
+    tickerhandler.add(char, 6, hook_key='at_turn_start')
     skills.apply_skills(char)
+    skills.finalize_skills(char.skills)

--- a/world/equip.py
+++ b/world/equip.py
@@ -58,7 +58,7 @@ Example usage:
     > for slot, item in character.equip:
     >     print "%s: %s" % (slot, item)
     'head: a hat'
-    > character.equip.head
+    > character.equip.get('head')
     'a hat'
     > character.equip.remove(obj)
     True


### PR DESCRIPTION
Fixed three small issues relating to items:
- `TwoHandedWeapon` multiple inheritance was incorrect. 
- Changed attribute existence testing to use `.attributes.has()` instead of `hasattr`
- Fixed error when inventory contains only items with no damage/toughness/range attributes.

Also beefed up equip-related tests to catch these.
