### PR TITLE
re-enabled the 'quit' command from within the chargen menu

### DIFF
--- a/commands/chargen.py
+++ b/commands/chargen.py
@@ -191,6 +191,5 @@ class CmdCharCreate(MuxPlayerCommand):
         EvMenu(session,
                "world.chargen",
                startnode=startnode,
-               auto_quit=False,
                cmd_on_exit=finish_char_callback)
 


### PR DESCRIPTION
Removed the EvMenu argument to suppress the 'quit' command.

Addresses Issue #73 
