### PR TITLE
NPC Stub

### DIFF
--- a/commands/building.py
+++ b/commands/building.py
@@ -59,6 +59,8 @@ class CmdSpawn(MuxCommand):
       |wpermissions|n - string or list of permission strings
       |wlocks      |n - a lock-string
       |waliases    |n - string or list of strings
+      |wtraits     |n - dict of trait:value pairs to set on NPCs
+      |wskills     |n - dict of skill:value pairs to set on NPCs
       |wndb_|n<name>  - value of a nattribute (ndb_ is stripped)
       any other keywords are interpreted as Attributes and their values.
 

--- a/commands/building.py
+++ b/commands/building.py
@@ -1,0 +1,123 @@
+
+
+from .command import MuxCommand
+from evennia import utils, CmdSet
+from evennia.utils.spawner import spawn
+from evennia.commands.default.building import _convert_from_string
+
+
+class AinneveBuildingCmdSet(CmdSet):
+    """
+    Implements Ainneve-specific buliding commands.
+    """
+    key = "AinneveBuilding"
+    priority = 0
+
+    def at_cmdset_creation(self):
+        "Populates the cmdset"
+        self.add(CmdSpawn())
+
+#
+# To use the prototypes with the @spawn function set
+#   PROTOTYPE_MODULES = ["commands.prototypes"]
+# Reload the server and the prototypes should be available.
+#
+
+class CmdSpawn(MuxCommand):
+    """
+    spawn objects from prototype
+
+    Usage:
+      @spawn
+      @spawn[/switch] prototype_name
+      @spawn[/switch] {prototype dictionary}
+
+    Switch:
+      noloc - allow location to be None if not specified explicitly. Otherwise,
+              location will default to caller's current location.
+
+    Example:
+      @spawn GOBLIN
+      @spawn {"key":"goblin", "typeclass":"monster.Monster", "location":"#2"}
+
+    Dictionary keys:
+      |wprototype  |n - name of parent prototype to use. Can be a list for
+                        multiple inheritance (inherits left to right)
+      |wkey        |n - string, the main object identifier
+      |wtypeclass  |n - string, if not set, will use settings.BASE_OBJECT_TYPECLASS
+      |wlocation   |n - this should be a valid object or #dbref
+      |whome       |n - valid object or #dbref
+      |wdestination|n - only valid for exits (object or dbref)
+      |wpermissions|n - string or list of permission strings
+      |wlocks      |n - a lock-string
+      |waliases    |n - string or list of strings
+      |wndb_|n<name>  - value of a nattribute (ndb_ is stripped)
+      any other keywords are interpreted as Attributes and their values.
+
+    The available prototypes are defined globally in modules set in
+    settings.PROTOTYPE_MODULES. If @spawn is used without arguments it
+    displays a list of available prototypes.
+    """
+
+    key = "@spawn"
+    aliases = ["spawn"]
+    locks = "cmd:perm(spawn) or perm(Builders)"
+    help_category = "Building"
+
+    def func(self):
+        "Implements the spawner"
+
+        def _show_prototypes(prototypes):
+            "Helper to show a list of available prototypes"
+            string = "\nAvailable prototypes:\n %s"
+            string = string % utils.fill(", ".join(sorted(prototypes.keys())))
+            return string
+
+        prototypes = spawn(return_prototypes=True)
+        if not self.args:
+            string = "Usage: @spawn {key:value, key, value, ... }"
+            self.caller.msg(string + _show_prototypes(prototypes))
+            return
+        try:
+            # make use of _convert_from_string from the SetAttribute command
+            prototype = _convert_from_string(self, self.args)
+        except SyntaxError:
+            # this means literal_eval tried to parse a faulty string
+            string = "|RCritical Python syntax error in argument. "
+            string += "Only primitive Python structures are allowed. "
+            string += "\nYou also need to use correct Python syntax. "
+            string += "Remember especially to put quotes around all "
+            string += "strings inside lists and dicts.|n"
+            self.caller.msg(string)
+            return
+
+        if isinstance(prototype, basestring):
+            # A prototype key
+            keystr = prototype
+            prototype = prototypes.get(prototype, None)
+            if not prototype:
+                string = "No prototype named '%s'." % keystr
+                self.caller.msg(string + _show_prototypes(prototypes))
+                return
+        elif not isinstance(prototype, dict):
+            self.caller.msg("The prototype must be a prototype key or a Python dictionary.")
+            return
+
+        if not "noloc" in self.switches and not "location" in prototype:
+            prototype["location"] = self.caller.location
+
+        # overridden for Ainneve
+        traits = prototype.pop('traits') if 'traits' in prototype else None
+        skills = prototype.pop('skills') if 'skills' in prototype else None
+
+        for obj in spawn(prototype):
+            obj.sdesc.add(obj.key)
+            if hasattr(obj, 'traits') and traits:
+                for trait, value in traits.iteritems():
+                    obj.traits[trait].base = value
+            if hasattr(obj, 'skills') and skills:
+                for skill, value in skills.iteritems():
+                    obj.skills[skill].base = value
+
+            self.caller.msg("Spawned %s." % obj.get_display_name(self.caller))
+

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -15,7 +15,7 @@ own cmdsets by inheriting from them or directly from `evennia.CmdSet`.
 """
 
 from evennia import default_cmds
-from commands import equip, chartraits, room_exit, chargen
+from commands import equip, chartraits, room_exit, chargen, building
 
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
@@ -37,6 +37,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(equip.EquipCmdSet())
         self.add(chartraits.CharTraitCmdSet())
         self.add(room_exit.AinneveRoomExitsCmdSet())
+        self.add(building.AinneveBuildingCmdSet())
 
 class PlayerCmdSet(default_cmds.PlayerCmdSet):
     """

--- a/commands/room_exit.py
+++ b/commands/room_exit.py
@@ -48,7 +48,7 @@ class CmdTerrain(MuxCommand):
         terrain = self.rhs.strip().upper()
         lhs = self.lhs.strip()
         if lhs != '':
-            target = self.caller.search(lhs)
+            target = self.caller.search(lhs, global_search=True)
         else:
             target = self.caller.location
 
@@ -95,11 +95,12 @@ class CmdRangeField(MuxCommand):
             return
 
         # range_field has to be set as a tuple; parse the string input
-        rf_re = re.compile(r'\(?\s*(\d+)\s*,\s*(\d+)\s*\)?', re.UNICODE)
+        rf_re = re.compile(r'(?:\(\s*(\d+)\s*,\s*(\d+)\s*\)|^\s*(\d+)\s*,\s*(\d+)\s*$)', re.UNICODE)
         rf_match = rf_re.search(self.rhs)
 
         if rf_match:
-            range_field = tuple(sorted((int(x) for x in rf_match.groups()),
+            range_field = tuple(sorted((int(x) for x in rf_match.groups()
+                                        if x is not None),
                                        reverse=True))
         else:
             self.caller.msg("Invalid range field specified.")
@@ -107,7 +108,7 @@ class CmdRangeField(MuxCommand):
 
         lhs = self.lhs.strip()
         if lhs != '':
-            target = self.caller.search(self.lhs.strip())
+            target = self.caller.search(lhs, global_search=True)
         else:
             target = self.caller.location
 

--- a/commands/tests.py
+++ b/commands/tests.py
@@ -5,8 +5,11 @@ from evennia.utils.test_resources import EvenniaTest
 from evennia.commands.default.tests import CommandTest
 from commands.equip import *
 from commands.chartraits import CmdSheet, CmdTraits
-from typeclasses.characters import Character
+from commands.room_exit import CmdRangeField, CmdTerrain
+from commands.building import CmdSpawn, CmdSetTraits, CmdSetSkills
+from typeclasses.characters import Character, NPC
 from typeclasses.weapons import Weapon
+from typeclasses.rooms import Room
 from world.races import apply_race
 from world.archetypes import apply_archetype, calculate_secondary_traits
 from utils.utils import sample_char
@@ -251,3 +254,119 @@ class CharTraitsTestCase(CommandTest):
 " Melee Attack     :    9  Ranged Attack    :    2  Unarmed Attack   :    5 \n"
 " Defense          :    5  Power Points     :    2")
         self.call(CmdTraits(), "com", output)
+
+
+class BuildingTestCase(CommandTest):
+    """Test case for Builder commands."""
+    def setUp(self):
+        self.character_typeclass = Character
+        self.object_typeclass = NPC
+        self.room_typeclass = Room
+        super(BuildingTestCase, self).setUp()
+
+    def test_terrain_cmd(self):
+        """test @terrain command"""
+        # no args gives usage
+        self.call(CmdTerrain(), "", "Usage: @terrain [<room>] = <terrain>")
+        # equal sign only gives usage
+        self.call(CmdTerrain(), "=", "Usage: @terrain [<room>] = <terrain>")
+        # setting terrain on current room
+        self.call(CmdTerrain(), "= DIFFICULT", "Terrain type 'DIFFICULT' set on Room.")
+        self.assertEqual(self.room1.terrain, 'DIFFICULT')
+        # terrain is case insensitive
+        self.call(CmdTerrain(), "= vegetation", "Terrain type 'VEGETATION' set on Room.")
+        self.assertEqual(self.room1.terrain, 'VEGETATION')
+        # attempt with invalid terrain name
+        self.call(CmdTerrain(), "= INVALID", "Invalid terrain type.")
+        self.assertEqual(self.room1.terrain, 'VEGETATION')
+        # setting terrain on a different room
+        self.call(CmdTerrain(), "Room2 = QUICKSAND", "Terrain type 'QUICKSAND' set on Room2.")
+
+    def test_rangefield_cmd(self):
+        """test @rangefield command"""
+        # no args
+        self.call(CmdRangeField(), "", "Usage: @rangefield [<room>] = (<length>, <width>)")
+        # equal sign only
+        self.call(CmdRangeField(), "=", "Usage: @rangefield [<room>] = (<length>, <width>)")
+        # setting range field on current room
+        self.call(CmdRangeField(), "= (5, 4)", "Range field set on Room.")
+        self.assertEqual(self.room1.range_field, (5, 4))
+        # parentheses are optional and whitespace allowed
+        self.call(CmdRangeField(), "= 3 , 3", "Range field set on Room.")
+        self.assertEqual(self.room1.range_field, (3, 3))
+        # invalid variations
+        self.call(CmdRangeField(), "= 5", "Invalid range field specified.")
+        self.call(CmdRangeField(), "= (3, 4", "Invalid range field specified.")
+        self.call(CmdRangeField(), "= 3, 4)", "Invalid range field specified.")
+        self.call(CmdRangeField(), "= (3, 4, 5)", "Invalid range field specified.")
+        self.call(CmdRangeField(), "= 3, 4, 5", "Invalid range field specified.")
+        self.assertEqual(self.room1.range_field, (3, 3))
+        # setting range field on a different room
+        self.call(CmdRangeField(), "Room2 = (10, 3)", "Range field set on Room2.")
+        self.assertEqual(self.room2.range_field, (10, 3))
+
+    def test_settraits_cmd(self):
+        """test @traits command"""
+        # no args
+        self.call(CmdSetTraits(), "", "Usage: @traits <npc> [trait[,trait..][ = value[,value..]]]")
+        # display object's traits
+        self.call(CmdSetTraits(), "Obj", "| Dexterity         :    1 | Black Mana        :    0 | Health            :    0 | Perception        :    1 | Action Points     :    0 | Defense           :    0 | Power Points      :    0 | Level             :    0 | White Mana        :    0 | Charisma          :    1 | Carry Weight      :    0 | Magic             :    0 | Reflex Save       :    0 | Strength          :    1 | Experience        :    0 | Fortitude Save    :    0 | Melee Attack      :    0 | Intelligence      :    1 | Stamina           :    0 | Will Save         :    0 | Movement Points   :    6 | Vitality          :    1 | Unarmed Attack    :    0 | Ranged Attack     :    0")
+        # display specific named traits
+        self.call(CmdSetTraits(), "Obj STR,BM,WM,INT,FORT", "| Strength          :    1 | Black Mana        :    0 | White Mana        :    0 | Intelligence      :    1 | Fortitude Save    :    0 |")
+        # ignore invalid traits for display
+        self.call(CmdSetTraits(), "Obj STR,INVALID", "| Strength          :    1")
+        # assign a trait
+        self.call(CmdSetTraits(), "Obj STR = 8", 'Trait "STR" set to 8 for A normal person|\n| Strength          :    8')
+        self.assertEqual(self.obj1.traits.STR.actual, 8)
+        # ignore invalid traits in assignment
+        self.call(CmdSetTraits(), "Obj STR,INVALID,PER = 7,5,6", 'Trait "STR" set to 7 for A normal person|Invalid trait: "INVALID"|Trait "PER" set to 6 for A normal person|\n| Strength          :    7 | Perception        :    6')
+        self.assertEqual(self.obj1.traits.STR.actual, 7)
+        self.assertEqual(self.obj1.traits.PER.actual, 6)
+        # handle invalid arg combinations
+        self.call(CmdSetTraits(), "Obj INVALID", "Could not find 'Obj INVALID'.")
+        self.call(CmdSetTraits(), "Obj STR, INT = 5, 6, 7", "Incorrect number of assignment values.")
+        self.call(CmdSetTraits(), "Obj STR = X", "Assignment values must be numeric.")
+
+    def test_setskills_cmd(self):
+        """test @skills command"""
+        #no args
+        self.call(CmdSetSkills(), "", "Usage: @skills <npc> [skill[,skill..][ = value[,value..]]]")
+        # display object's skills
+        self.call(CmdSetSkills(), "Obj", "| Appraise          :    1 | Animal Handle     :    1 | Barter            :    1 | Throwing          :    1 | Survival          :    1 | Escape            :    1 | Sneak             :    1 | Jump              :    1 | Leadership        :    1 | Lock Pick         :    1 | Sense Danger      :    1 | Medicine          :    1 | Climb             :    1 | Balance           :    1 | Listen            :    1")
+        # display named skills
+        self.call(CmdSetSkills(), "Obj escape,jump,medicine,survival", "| Escape            :    1 | Jump              :    1 | Medicine          :    1 | Survival          :    1 |")
+        # ignore invalid skills for display
+        self.call(CmdSetSkills(), "Obj sense, notaskill", "| Sense Danger      :    1")
+        # assign a skill
+        self.call(CmdSetSkills(), "Obj jump = 4", 'Skill "jump" set to 4 for A normal person|\n| Jump              :    4')
+        self.assertEqual(self.obj1.skills.jump.actual, 4)
+        # ignore invalid skills in assignment
+        self.call(CmdSetSkills(), "Obj barter,sneak,noskill = 3, 4, 10", 'Skill "barter" set to 3 for A normal person|Skill "sneak" set to 4 for A normal person|Invalid skill: "noskill"|\n| Barter            :    3 | Sneak             :    4')
+        self.assertEqual(self.obj1.skills.barter.actual, 3)
+        self.assertEqual(self.obj1.skills.sneak.actual, 4)
+        # handle invalid arg combinations
+        self.call(CmdSetSkills(), "Obj INVALID", "Could not find 'Obj INVALID'.")
+        self.call(CmdSetSkills(), "Obj leadership, animal = 2, 3, 2", "Incorrect number of assignment values.")
+        self.call(CmdSetSkills(), "Obj escape = X", "Assignment values must be numeric.")
+
+    def test_spawn_cmd(self):
+        """test overridden @spawn command"""
+        # no args
+        self.call(CmdSpawn(), "", "Usage: @spawn {key:value, key, value, ... }\nAvailable prototypes:")
+        # spawn prototype with traits and skills
+        proto = "{'key': 'a bunny', 'typeclass': 'typeclasses.characters.NPC', 'traits':{'STR': 2, 'PER': 3, 'INT': 2, 'DEX': 4, 'CHA': 4, 'VIT': 2}, 'skills':{'escape': 5, 'jump': 6, 'medicine': 1, 'sneak': 2}}"
+        self.call(CmdSpawn(), proto, "Spawned a bunny(#8).")
+        bunny = self.room1.contents[-1]
+        self.assertEqual(bunny.key, "a bunny")
+        self.assertEqual(bunny.sdesc.get(), "a bunny")
+        self.assertTrue(bunny.is_typeclass('typeclasses.characters.NPC'))
+        self.assertEqual(bunny.traits.STR, 2)
+        self.assertEqual(bunny.traits.PER, 3)
+        self.assertEqual(bunny.traits.INT, 2)
+        self.assertEqual(bunny.traits.DEX, 4)
+        self.assertEqual(bunny.traits.CHA, 4)
+        self.assertEqual(bunny.traits.VIT, 2)
+        self.assertEqual(bunny.skills.escape, 5)
+        self.assertEqual(bunny.skills.jump, 6)
+        self.assertEqual(bunny.skills.medicine, 1)
+        self.assertEqual(bunny.skills.sneak, 2)

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -11,6 +11,7 @@ from evennia.contrib.rpsystem import ContribRPCharacter
 from evennia.utils import lazy_property
 from world.equip import EquipHandler
 from world.traits import TraitHandler
+from world.skills import apply_skills
 from world.archetypes import Archetype
 
 
@@ -68,5 +69,5 @@ class NPC(Character):
         for key, kwargs in npc.traits.iteritems():
             self.traits.add(key, **kwargs)
 
-
+        apply_skills(self)
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -11,6 +11,7 @@ from evennia.contrib.rpsystem import ContribRPCharacter
 from evennia.utils import lazy_property
 from world.equip import EquipHandler
 from world.traits import TraitHandler
+from world.archetypes import Archetype
 
 
 class Character(ContribRPCharacter):
@@ -54,3 +55,18 @@ class Character(ContribRPCharacter):
         self.traits.WM.fill_gauge()
         # Power Points are lost each turn
         self.traits.PP.reset_counter()
+
+
+class NPC(Character):
+    """Base character typeclass for NPCs and enemies.
+    """
+    def at_object_creation(self):
+        super(NPC, self).at_object_creation()
+
+        # initialize traits
+        npc = Archetype()
+        for key, kwargs in npc.traits.iteritems():
+            self.traits.add(key, **kwargs)
+
+
+


### PR DESCRIPTION
- Stubs out a basic NPC typeclass, which gets loaded with minimal default traits and skills.
- Adds support for including `traits` and `skills` keys within spawner prototype dictionaries.
- Adds builder commands `@traits` and `@skills` to allow builders to edit corresponding attributes on NPCs.
