### PR TITLE
Dynamic sdescs fix for prototypes

### DIFF
--- a/commands/tests.py
+++ b/commands/tests.py
@@ -28,7 +28,7 @@ class ItemEncumbranceTestCase(EvenniaTest):
         self.obj1.db.weight = 1.0
         self.obj2.swap_typeclass('typeclasses.armors.Armor',
                                  clean_attributes=True,
-                                 run_start_hooks=True)
+                                 run_start_hooks="all")
         self.obj2.db.toughness = 1
         self.obj2.db.weight = 18.0
 
@@ -69,7 +69,7 @@ class EquipTestCase(CommandTest):
         self.obj2.db.desc = 'Test Obj2'
         self.obj2.swap_typeclass('typeclasses.armors.Armor',
                                  clean_attributes=True,
-                                 run_start_hooks=True)
+                                 run_start_hooks="all")
         self.obj2.db.toughness = 1
         self.obj2.db.weight = 2.0
 
@@ -92,7 +92,7 @@ class EquipTestCase(CommandTest):
         """test wield command for 2H weapons"""
         self.obj1.swap_typeclass('typeclasses.weapons.TwoHandedWeapon',
                                  clean_attributes=True,
-                                 run_start_hooks=True)
+                                 run_start_hooks="all")
         self.obj1.db.damage = 1
         self.obj1.db.weight = 1.0
         # pick it up to wield the weapon
@@ -107,7 +107,7 @@ class EquipTestCase(CommandTest):
         """test wield command for 1H ranged weapons"""
         self.obj1.swap_typeclass('typeclasses.weapons.RangedWeapon',
                                  clean_attributes=True,
-                                 run_start_hooks=True)
+                                 run_start_hooks="all")
         self.obj1.db.damage = 1
         self.obj1.db.weight = 1.0
         self.obj1.db.range = 5
@@ -123,7 +123,7 @@ class EquipTestCase(CommandTest):
         """test wield command for 2H ranged weapons"""
         self.obj1.swap_typeclass('typeclasses.weapons.TwoHandedRanged',
                                  clean_attributes=True,
-                                 run_start_hooks=True)
+                                 run_start_hooks="all")
         self.obj1.db.damage = 1
         self.obj1.db.weight = 1.0
         self.obj1.db.range = 5

--- a/world/chargen.py
+++ b/world/chargen.py
@@ -530,7 +530,7 @@ def menunode_confirm(caller, raw_string):
          char.db.focus,
          char.db.desc) = [None for _ in xrange(4)]
 
-        char.sdesc.add('')
+        char.sdesc.add('a normal person')
         char.db.wallet = {'GC': 0, 'SC': 0, 'CC': 0}
         char.traits.clear()
         char.skills.clear()

--- a/world/content/prototypes_mobs.py
+++ b/world/content/prototypes_mobs.py
@@ -33,7 +33,7 @@ SAMPLE_NPC = {
 
 RAT = {
     "key":"a rat npc",
-    "sdesc": lambda: "a {} {} rat".format(random.choice(rat_adj_1),random.choice(rat_adj_2)),
+    "sdesc": lambda: "{}, {} rat".format(random.choice(rat_adj_1),random.choice(rat_adj_2)),
     "tag": ["NPC"],
     "typeclass": "typeclasses.characters.NPC",
     "desc": "Beware of rat poison.",
@@ -86,8 +86,8 @@ DEER = {
 }
 WOLF = {
     "key":"a wolf npc",
-    "sdesc": lambda: "{} {} wolf".format(random.choice(wolf_adj_1),random.choice(wolf_adj_2)),
-    "tag": ["NPC","AGGRESSIVE"],
+    "sdesc": lambda: "{}, {} wolf".format(random.choice(wolf_adj_1),random.choice(wolf_adj_2)),
+    "tag": ["NPC", "AGGRESSIVE"],
     "typeclass": "typeclasses.characters.NPC",
     "desc": "Oh look, here's a wolf. It's probably going to attempt to eat you.",
     "traits": {'STR': 5, 'DEX': 5, 'PER': 5, 'CHA': 5, 'INT': 5, 'VIT': 5,
@@ -104,8 +104,8 @@ WOLF = {
 
 SPIDER = {
     "key": "a spider npc",
-    "sdesc": lambda: "{} {} spider".format(random.choice(spider_adj_1),random.choice(spider_adj_2)),
-    "tag": ["NPC","AGGRESSIVE"],
+    "sdesc": lambda: "{}, {} spider".format(random.choice(spider_adj_1),random.choice(spider_adj_2)),
+    "tag": ["NPC", "AGGRESSIVE"],
     "typeclass": "typeclasses.characters.NPC",
     "desc": "Need a hand? Well just you wait. We'll help you out, we each have eight.",
     "traits": {'STR': 5, 'DEX': 5, 'PER': 5, 'CHA': 5, 'INT': 5, 'VIT': 5,
@@ -122,8 +122,8 @@ SPIDER = {
 
 ORC = {
     "key": "an orc npc",
-    "sdesc": lambda: "{} {} orc".format(random.choice(orc_adj_1),random.choice(orc_adj_2)),
-    "tag": ["NPC","AGGRESSIVE"],
+    "sdesc": lambda: "{}, {} orc".format(random.choice(orc_adj_1),random.choice(orc_adj_2)),
+    "tag": ["NPC", "AGGRESSIVE"],
     "exec": "obj.execute_cmd('say My tags include {}'.format(obj.db.tag))",
     "typeclass": "typeclasses.characters.NPC",
     "desc": "An intellectual creature at heart, the orc is a misunderstood beast who simply desires to be understood and loved. It expresses this love through extreme violence.",

--- a/world/content/prototypes_mobs.py
+++ b/world/content/prototypes_mobs.py
@@ -86,7 +86,7 @@ DEER = {
 }
 WOLF = {
     "key":"a wolf npc",
-    "sdesc": lambda: "a {} {} wolf".format(random.choice(wolf_adj_1),random.choice(wolf_adj_2)),
+    "sdesc": lambda: "{} {} wolf".format(random.choice(wolf_adj_1),random.choice(wolf_adj_2)),
     "tag": ["NPC","AGGRESSIVE"],
     "typeclass": "typeclasses.characters.NPC",
     "desc": "Oh look, here's a wolf. It's probably going to attempt to eat you.",
@@ -104,7 +104,7 @@ WOLF = {
 
 SPIDER = {
     "key": "a spider npc",
-    "sdesc": lambda: "a {} {} spider".format(random.choice(spider_adj_1),random.choice(spider_adj_2)),
+    "sdesc": lambda: "{} {} spider".format(random.choice(spider_adj_1),random.choice(spider_adj_2)),
     "tag": ["NPC","AGGRESSIVE"],
     "typeclass": "typeclasses.characters.NPC",
     "desc": "Need a hand? Well just you wait. We'll help you out, we each have eight.",
@@ -122,7 +122,7 @@ SPIDER = {
 
 ORC = {
     "key": "an orc npc",
-    "sdesc": lambda: "a {} {} orc".format(random.choice(orc_adj_1),random.choice(orc_adj_2)),
+    "sdesc": lambda: "{} {} orc".format(random.choice(orc_adj_1),random.choice(orc_adj_2)),
     "tag": ["NPC","AGGRESSIVE"],
     "exec": "obj.execute_cmd('say My tags include {}'.format(obj.db.tag))",
     "typeclass": "typeclasses.characters.NPC",

--- a/world/content/sdesc_vars.py
+++ b/world/content/sdesc_vars.py
@@ -1,7 +1,22 @@
 """
-Variables
+Variables for dynamic sdesc generation
 """
-spider_adj_1 = [
+
+
+def with_articles(wordlist):
+    """Prepends the appropriate article to a list of words"""
+    output = []
+    vowels = 'aeiou'
+    for word in wordlist:
+        if word[0] in vowels:
+            output.append("an {}".format(word))
+        else:
+            output.append("a {}".format(word))
+
+    return output
+
+
+spider_adj_1 = with_articles([
     "brown-striped",
     "coal-black",
     "grey",
@@ -20,7 +35,7 @@ spider_adj_1 = [
     "repulsive",
     "green-striped",
     "dusty-grey",
-]
+])
 
 spider_adj_2 = [
     "long-legged",
@@ -42,7 +57,7 @@ spider_adj_2 = [
     "sleek",
 ]
 
-rat_adj_1 = [
+rat_adj_1 = with_articles([
     "brown",
     "ochre-furred",
     "grey",
@@ -65,7 +80,7 @@ rat_adj_1 = [
     "rotting-toothed",
     "large-pawed",
     "small-pawed",
-]
+])
 
 rat_adj_2 = [
     "scrawny",
@@ -93,7 +108,7 @@ rat_adj_2 = [
     "crippled",
 ]
 
-bird_adj_1 = [
+bird_adj_1 = with_articles([
     "tiny",
     "miniscule",
     "small",
@@ -141,7 +156,7 @@ bird_adj_1 = [
     "striped",
     "spotted",
     "dappled",
-]
+])
 
 bird_adj_2 = [
     "sharp-beaked",
@@ -178,7 +193,7 @@ bird_adj_2 = [
     "crowned",
 ]
 
-troll_adj_1 = [
+troll_adj_1 = with_articles([
     "immense",
     "huge",
     "gigantic",
@@ -220,7 +235,7 @@ troll_adj_1 = [
     "shiny-scalped",
     "wiry-haired",
     "bristly-haired",
-]
+])
 
 troll_adj_2 = [
     "slime-green-eyed",
@@ -269,7 +284,7 @@ troll_adj_2 = [
     "ulcerous-skinned",
 ]
 
-wolf_adj_1 = [
+wolf_adj_1 = with_articles([
     "sinewy",
     "muscular",
     "powerfully-muscled",
@@ -316,7 +331,7 @@ wolf_adj_1 = [
     "dark-brown",
     "muddy-brown",
     "matted-furred",
-]
+])
 
 wolf_adj_2 = [
     "narrow-muzzled",
@@ -351,7 +366,7 @@ wolf_adj_2 = [
     "feral",
 ]
 
-elf_adj_1 = [
+elf_adj_1 = with_articles([
     "fair",
     "ethereal",
     "graceful",
@@ -427,7 +442,7 @@ elf_adj_1 = [
     "silver-eyed",
     "hazel-eyed",
     "cinnamon-eyed",
-]
+])
 
 elf_adj_2 = [
     "black-haired",
@@ -456,7 +471,7 @@ elf_adj_2 = [
     "platinum-blonde-haired",
 ]
 
-human_adj_1 = [
+human_adj_1 = with_articles([
     "acned",
     "cadaverous",
     "dirty",
@@ -564,7 +579,7 @@ human_adj_1 = [
     "grey-eyed",
     "stormy-eyed",
     "hazel-eyed",
-]
+])
 
 human_adj_2 = [
     "black-haired",
@@ -613,7 +628,7 @@ human_adj_2 = [
     "delicate-shouldered",
 ]
 
-dwarf_adj_1 = [
+dwarf_adj_1 = with_articles([
     "florid-faced",
     "short",
     "compact",
@@ -676,7 +691,7 @@ dwarf_adj_1 = [
     "grey-eyed",
     "flint-eyed",
     "hazel-eyed",
-]
+])
 
 dwarf_adj_2 = [
     "black-haired",
@@ -721,7 +736,7 @@ dwarf_adj_2 = [
     "broad-shouldered",
 ]
 
-orc_adj_1 = [
+orc_adj_1 = with_articles([
     "acned",
     "froglike",
     "stumpy",
@@ -815,7 +830,7 @@ orc_adj_1 = [
     "potbellied",
     "flat-headed",
     "hollow-eyed",
-]
+])
 
 orc_adj_2 = [
     "black-haired",
@@ -863,7 +878,7 @@ orc_adj_2 = [
     "small-tusked",
 ]
 
-goblin_adj_1 = [
+goblin_adj_1 = with_articles([
     "acned",
     "cadaverous",
     "dirty",
@@ -931,7 +946,7 @@ goblin_adj_1 = [
     "dark-skinned",
     "wrinkled",
     "hollow-eyed",
-]
+])
 
 goblin_adj_2 = [
     "black-haired",

--- a/world/test_chargen.py
+++ b/world/test_chargen.py
@@ -630,14 +630,15 @@ class ChargenTestCase(EvenniaTest):
         self.session.execute_cmd('done')
         self.session.execute_cmd('test sdesc')
         self.session.execute_cmd('test description')
-        self.session.execute_cmd('n')
+        self.session.execute_cmd('no')
+
         self.assertEqual(len(self.char1.traits.all), 0)
         self.assertEqual(len(self.char1.skills.all), 0)
         self.assertEqual(len(self.char1.contents), 0)
         self.assertIsNone(self.char1.db.archetype)
         self.assertIsNone(self.char1.db.race)
         self.assertIsNone(self.char1.db.focus)
-        self.assertEqual(self.char1.sdesc.get(), '')
+        self.assertEqual(self.char1.sdesc.get(), 'a normal person')
         self.assertIsNone(self.char1.db.desc)
         self.assertDictEqual(dict(self.char1.db.wallet),
                              {'GC': 0, 'SC': 0, 'CC': 0})


### PR DESCRIPTION
This is a solution to closed Issue #82. It creates a helper function that prepends "a" or "an" as needed to all words in a list. The function has been inserted into the creation of `*_adj_1` variables, and the lambdas updated accordingly.

However, one concern I have about this approach is that the search mechanism in the `rpsystem` module's base typeclasses does not accept partial words in the sdesc, which means that, given "an ochre-furred, golden-eyed wolf", you will not be able to say 'attack ochre' and have it resolve correctly. It would instead require input like 'attack ochre-furred' to work.

Of course 'attack wolf' would always work, but in a room full of wolves, it would fall back to needing '1-wolf'-style differentiation, and it seems like the purpose of creating all these lengthy, adjective-laden sdescs would be to allow players to avoid using the #-wolf syntax for the most part. 

So I guess that's something to discuss. I saw someone in the IRC channel recently expressing their desire to have `startswith()` style matching for all parsed arguments, which is essentially what is needed here. That, or a more sophisticated prototype-generating system that gracefully handles setting the dynamic sdesc along with matching shortened-form aliases.
