### PR TITLE
Return_appearance changes

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -141,6 +141,9 @@ class Character(ContribRPCharacter):
                 string += "They seem to be in pretty bad shape.\n"
             else:
                 string += "They're dead.\n"
+        # if we don't know their health, then just show a default message
+        else:
+            string += "They seem to be in good health.\n"
 
         if knows_stamina and self.traits.HP.actual > 0: # we check HP.actual,
                                                         # in case they're dead

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -103,20 +103,20 @@ class Character(ContribRPCharacter):
         # These each do a skill check, but they always pass
         # if you're looking at yourself
         knows_race = skill_check(per) or looker == self
-        knows_archetype = skill_check(per, 6) or looker == self
-        knows_health = skill_check(per, 7) or looker == self
-        knows_stamina = skill_check(per, 7) or looker == self
+        knows_archetype = skill_check(per) or looker == self
+        knows_health = skill_check(per) or looker == self
+        knows_stamina = skill_check(per) or looker == self
 
         # this is the base name format - it just colors the name cyan
         string = "|c%s|n" % name
 
         # if we're adding race or archetype, add "the" after the name
-        if knows_race or knows_archetype:
+        if (knows_race and self.db.archetype) or (knows_archetype and self.db.archetype):
             string += " the"
 
-        if knows_race:
+        if knows_race and self.db.race:
             string += " {}".format(self.db.race)
-        if knows_archetype:
+        if knows_archetype and self.db.archetype:
             string += " {}".format(self.db.archetype)
 
         # There may be a more efficient way to do this,

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -120,7 +120,7 @@ class Character(ContribRPCharacter):
         string = "|c%s|n" % name
 
         # if we're adding race or archetype, add "the" after the name
-        if (knows_race) or (knows_archetype):
+        if knows_race or knows_archetype:
             string += " the"
 
         if knows_race:

--- a/world/races.py
+++ b/world/races.py
@@ -195,8 +195,8 @@ class Race(object):
             'armor': None,
         }
         self.limbs = (
-            ('r_arm', ('wield1',)),
-            ('l_arm', ('wield2',)),
+            ('right arm', ('wield1',)),
+            ('left arm', ('wield2',)),
             ('body', ('armor',)),
         )
         self.foci = []


### PR DESCRIPTION
This change addresses #57 by adding a customized return_appearance to the Character typeclass.

This hook shows the name, and if the looker passes perception checks, the race and archetype like so:
**Chainsol** the **Elf** **Arcanist**

Another perception check tells the looker how healthy the target is - right now, there are four messages at 80%, 50%, anything over 0, and 0 HP.

Another check tells you how much stamina they have left, also with three messages at 80%, 50%, and anything below 50%.

Finally, the return_appearance hook also doesn't show the looker the contents of the target's inventory, and instead only shows what they have equipped. To this end, the hook uses the target's EquipHandler and the limbs the target has.

To make the limbs more readable, the limbs of the default characters have been changed to be human-readable instead of shortened: right arm instead of r_arm.

The only thing I remain unsure of is the difficulty of the perception checks, and if we should store and remember the result for a period of time, so the checks are only re-performed after a period of time, say, 5 minutes?