### PR TITLE
Reintegrate real-time combat

### DIFF
--- a/commands/combat.py
+++ b/commands/combat.py
@@ -1,0 +1,228 @@
+"""
+Combat commands.
+"""
+
+from evennia import CmdSet
+from .command import Command
+from world.combat import CombatHandler
+
+from random import choice
+
+class CmdInitiateCombat(Command):
+    """Engage an opponent in combat."""
+    key = "attack"
+    aliases = ("engage",)
+    
+    def func(self):
+        caller = self.caller
+        args = self.args
+
+        target = caller.search(args)
+        if not target:
+            return
+
+        # get or make combat instance
+        combat = caller.ndb.combat
+        if not combat:
+            # caller is not in combat, so use the target's combat instance
+            combat = target.ndb.combat
+        if not combat:
+            # still no combat instance means neither are in combat; start new instance
+            combat = CombatHandler(caller, target)
+        elif combat != target.ndb.combat:
+            # both parties are in separate combat instances; combine into one
+            combat.merge(target.ndb.combat)
+        range = combat.get_range(caller, target)
+        caller.msg(f"You prepare for combat! {target.get_display_name(caller)} is at {range} range.")
+
+        # TODO: trigger combat prompt
+
+
+class CmdAdvance(Command):
+    """Advance towards a target."""
+    key = "advance"
+    aliases = ("approach",)
+    locks = "cmd:in_combat()"
+    
+    def func(self):
+        caller = self.caller
+        args = self.args
+
+        if not caller.cooldowns.ready("combat_move"):
+            caller.msg(f"You can't move for another {caller.cooldowns.time_left('combat_move',use_int=True)} seconds.")
+            return
+        
+        target = caller.search(args)
+        if not target:
+            return
+
+        combat = caller.ndb.combat
+        if combat.advance(caller, target):
+            # TODO: base movement cooldown on character stats
+            caller.cooldowns.add("combat_move",3)
+            range = combat.get_range(caller, target)
+            caller.location.msg_contents("{attacker} advances towards {target}.", exclude=caller, mapping={ "attacker": caller, "target": target })
+            caller.msg(f"You advance towards {target.get_display_name(caller)} and are now at {range} range.")
+        else:
+            caller.msg(f"You can't advance any further towards {target.get_display_name(caller)}.")
+
+        # TODO: trigger combat prompt
+
+
+class CmdRetreat(Command):
+    """Move away from a target."""
+    key = "retreat"
+    locks = "cmd:in_combat()"
+    
+    def func(self):
+        caller = self.caller
+        args = self.args
+
+        if not caller.cooldowns.ready("combat_move"):
+            caller.msg(f"You can't move for another {caller.cooldowns.time_left('combat_move',use_int=True)} seconds.")
+            return
+        
+        target = caller.search(args)
+        if not target:
+            return
+
+        combat = caller.ndb.combat
+        if combat.retreat(caller, target):
+            # TODO: base movement cooldown on character stats
+            caller.cooldowns.add("combat_move",3)
+            range = combat.get_range(caller, target)
+            caller.location.msg_contents("{attacker} retreats from {target}.", exclude=caller, mapping={ "attacker": caller, "target": target })
+            caller.msg(f"You retreat from {target.get_display_name(caller)} and are now at {range} range.")
+        else:
+            caller.msg(f"You can't retreat any further from {target.get_display_name(caller)}.")
+
+        # TODO: trigger combat prompt
+
+
+class CmdHit(Command):
+    """Basic melee combat attack."""
+    key = "hit"
+    locks = "cmd:in_combat() and melee_equipped() and in_range(melee)"
+
+    def func(self):
+        caller = self.caller
+        args = self.args
+        range = "melee"
+
+        if not caller.cooldowns.ready("attack"):
+            caller.msg(f"You can't attack for {caller.cooldowns.time_left('attack',use_int=True)} more seconds.")
+            return
+
+        target = caller.search(args)
+        if not target:
+            return
+
+        combat = caller.ndb.combat
+        hittable = combat.in_range(caller, target, range)
+        if hittable is None:
+            caller.msg("You can't fight that.")
+            return
+        elif not hittable:
+            caller.msg(f"{target.get_display_name(caller)} is too far away.")
+            return
+
+        # TODO: better handling of dual-wielding
+        weapon = caller.equip.get("wield1") or caller.equip.get("wield2")
+        dmg, cooldown = weapon.at_attack(caller, range)
+        
+        if not dmg:
+            caller.msg(f"You can't hit {target.get_display_name(caller)} with your {weapon.get_display_name(caller)}.")
+            return
+        
+        # apply damage and set cooldown
+        caller.cooldowns.add("attack", cooldown)
+        # TODO: add a damage check/application hook to characters and call here
+        caller.msg("This is where you would do the attack stuff if it was implemented.")
+
+        # TODO: trigger combat prompt
+
+
+class CmdShoot(Command):
+    """Basic ranged combat attack."""
+    key = "shoot"
+    locks = "cmd:in_combat() and ranged_equipped() and in_range(ranged)"
+
+    def func(self):
+        caller = self.caller
+        args = self.args
+        range = "ranged"
+
+        if not caller.cooldowns.ready("attack"):
+            caller.msg(f"You can't attack for {caller.cooldowns.time_left('attack',use_int=True)} more seconds.")
+            return
+
+        target = caller.search(args)
+        if not target:
+            return
+
+        combat = caller.ndb.combat
+        shootable = combat.in_range(caller, target, range)
+        if shootable is None:
+            caller.msg("You can't fight that.")
+            return
+        elif not shootable:
+            caller.msg(f"{target.get_display_name(caller)} is too far away.")
+            return
+
+        # TODO: better handling of dual-wielding
+        weapon = caller.equip.get("wield1") or caller.equip.get("wield2")
+        dmg, cooldown = weapon.at_attack(caller, range)
+        
+        if not dmg:
+            caller.msg(f"You can't shoot {target.get_display_name(caller)} with your {weapon.get_display_name(caller)}.")
+            return
+        
+        # apply damage and set cooldown
+        caller.cooldowns.add("attack", cooldown)
+        # TODO: add a damage check/application hook to characters and call here
+        caller.msg("This is where you would do the attack stuff if it was implemented.")
+
+        # TODO: trigger combat prompt
+
+
+class CmdFlee(Command):
+    """Command to disengage and escape from combat."""
+    key = "flee"
+    aliases = ("escape",)
+    locks = "cmd:in_combat()"
+    
+    def func(self):
+        caller = self.caller
+        args = self.args
+        
+        if not caller.cooldowns.ready("combat_move"):
+            caller.msg(f"You can't move for another {caller.cooldowns.time_left('combat_move',use_int=True)} seconds.")
+            return
+        
+        exits = [ex for ex in caller.location.contents if ex.destination]
+        if not exits:
+            caller.msg("There's nowhere to run!")
+            return
+
+        # TODO: add checks for flight success, e.g. `caller.at_pre_flee`
+
+        # this is the actual fleeing bit
+        caller.msg("You flee!")
+        caller.ndb.combat.remove(caller)
+        target = choice(exits)
+        # using execute_cmd instead of duplicating all the checks in ExitCommand
+        caller.execute_cmd(target.key)
+
+
+class CombatCmdSet(CmdSet):
+    """Command set containing combat commands"""
+    key = "combat_cmdset"
+
+    def at_cmdset_creation(self):
+        """Populate CmdSet"""
+        self.add(CmdInitiateCombat())
+        self.add(CmdHit())
+        self.add(CmdShoot())
+        self.add(CmdAdvance())
+        self.add(CmdRetreat())
+        self.add(CmdFlee())

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -20,6 +20,7 @@ from evennia.contrib.grid.xyzgrid.commands import XYZGridCmdSet
 from .debug import DebugCmdSet
 from .game import AinneveCmdSet
 from .ooc import CmdCharCreate
+from .combat import CombatCmdSet
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
     """
@@ -35,10 +36,11 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         Populates the cmdset
         """
         super().at_cmdset_creation()
-				
+        
         self.add(DebugCmdSet())  # commands for debugging purposes
         self.add(XYZGridCmdSet()) # xyzgrid pathfinding and building commands
         self.add(AinneveCmdSet()) # our own game commands
+        self.add(CombatCmdSet()) # combat-specific commands
 
 class AccountCmdSet(default_cmds.AccountCmdSet):
     """

--- a/server/conf/lockfuncs.py
+++ b/server/conf/lockfuncs.py
@@ -20,11 +20,33 @@ lock functions from evennia.locks.lockfuncs.
 
 """
 
-# def myfalse(accessing_obj, accessed_obj, *args, **kwargs):
-#    """
-#    called in lockstring with myfalse().
-#    A simple logger that always returns false. Prints to stdout
-#    for simplicity, should use utils.logger for real operation.
-#    """
-#    print "%s tried to access %s. Access denied." % (accessing_obj, accessed_obj)
-#    return False
+def in_combat(accessing_obj, accessed_obj, *args, **kwargs):
+    """returns true if an active combat handler is present"""
+    if hasattr(accessing_obj, 'nattributes'):
+        return accessing_obj.nattributes.has('combat')
+    else:
+        return False
+
+def in_range(accessing_obj, accessed_obj, *args, **kwargs):
+    """returns true if accessing_obj has any targets in specified range"""
+    range = args[0] if args else "MELEE"
+    if hasattr(accessing_obj, 'nattributes'):
+        if not (combat := accessing_obj.ndb.combat):
+            return False
+        return combat.any_in_range(accessing_obj, range)
+    else:
+        return false
+
+def melee_equipped(accessing_obj, accessed_obj, *args, **kwargs):
+    """returns true if accessing_obj has a melee weapon equipped"""
+    if hasattr(accessing_obj, 'weapon'):
+        return accessing_obj.weapon.attack_range.name == "MELEE"
+    else:
+      return False
+
+def ranged_equipped(accessing_obj, accessed_obj, *args, **kwargs):
+    """returns true if accessing_obj hsa a ranged weapon equipped"""
+    if hasattr(accessing_obj, 'weapon'):
+        return accessing_obj.weapon.attack_range.name == "RANGED"
+    else:
+      return False

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -1,0 +1,142 @@
+"""
+Test Ainneve's custom commands.
+
+"""
+
+from unittest.mock import call, patch
+
+from anything import Something
+
+from evennia.utils.create import create_object
+from evennia.utils.test_resources import EvenniaTest, EvenniaCommandTest
+
+from commands import combat
+from typeclasses.characters import Character
+from typeclasses.npcs import Mob, ShopKeeper
+
+from world.combat import CombatHandler
+from world.enums import CombatRange
+
+from .mixins import AinneveTestMixin
+
+
+class TestCombatHandler(AinneveTestMixin, EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.combat = CombatHandler(self.char1, self.char2)
+        self.combat.positions[self.char1] = 1
+        self.combat.positions[self.char2] = 2
+
+    def test_add_remove(self):
+        target = create_object(Mob, key="rat", location=self.room1)
+        self.combat.add(target)
+        self.assertTrue(target in self.combat.positions)
+        self.combat.remove(target)
+        self.assertFalse(target in self.combat.positions)
+
+    def test_approach(self):
+        self.combat.approach(self.char1, self.char2)
+        self.assertEqual(
+            self.combat.positions[self.char1], self.combat.positions[self.char2]
+        )
+        self.assertFalse(self.combat.approach(self.char1, self.char2))
+
+    def test_retreat(self):
+        # retreating negative
+        self.combat.retreat(self.char1, self.char2)
+        self.assertEqual(self.combat.positions[self.char1], 0)
+        self.assertEqual(self.combat.positions[self.char2], 2)
+        # retreating positive
+        self.combat.retreat(self.char2, self.char1)
+        self.assertEqual(self.combat.positions[self.char1], 0)
+        self.assertEqual(self.combat.positions[self.char2], 3)
+
+    def test_in_range(self):
+        self.assertTrue(self.combat.in_range(self.char1, self.char2, "MELEE"))
+        self.combat.positions[self.char2] = 5
+        self.assertFalse(self.combat.in_range(self.char1, self.char2, "MELEE"))
+        self.assertTrue(self.combat.in_range(self.char1, self.char2, "RANGED"))
+
+    def test_any_in_range(self):
+        self.assertTrue(self.combat.any_in_range(self.char1, "MELEE"))
+        self.combat.positions[self.char2] = 5
+        self.assertFalse(self.combat.any_in_range(self.char1, "MELEE"))
+        self.assertTrue(self.combat.any_in_range(self.char1, "RANGED"))
+
+    def test_get_range(self):
+        self.assertEqual(self.combat.get_range(self.char1, self.char2), "MELEE")
+        self.combat.positions[self.char2] = 5
+        self.assertEqual(self.combat.get_range(self.char1, self.char2), "RANGED")
+
+
+class TestCombatCommands(AinneveTestMixin, EvenniaCommandTest):
+    def setUp(self):
+        super().setUp()
+        self.target = create_object(Mob, key="rat", location=self.room1)
+
+    def tearDown(self):
+        super().tearDown()
+        self.target.delete()
+
+    def test_engage(self):
+        self.call(
+            combat.CmdInitiateCombat(),
+            "rat",
+            "You prepare for combat! rat is at melee range.",
+        )
+        self.assertEqual(self.char1.ndb.combat, self.target.ndb.combat)
+
+        self.call(
+            combat.CmdInitiateCombat(),
+            "char2",
+            "You can't attack another player here.",
+        )
+        self.call(
+            combat.CmdInitiateCombat(),
+            "obj",
+            "You can't attack that.",
+        )
+
+    def test_hit(self):
+        combat_instance = CombatHandler(self.char1, self.target)
+        self.call(
+            combat.CmdHit(),
+            "rat",
+            "You hit rat with your Empty Fists",
+        )
+        self.char1.cooldowns.clear()
+        combat_instance.retreat(self.char1, self.target)
+        self.call(
+            combat.CmdHit(),
+            "rat",
+            "rat is too far away.",
+        )
+
+    def test_shoot(self):
+        combat_instance = CombatHandler(self.char1, self.target)
+        self.weapon.attack_range = CombatRange.RANGED
+        self.weapon.location = self.char1
+        self.char1.equipment.move(self.weapon)
+        self.call(
+            combat.CmdShoot(),
+            "rat",
+            "You shoot rat with your weapon",
+        )
+        self.char1.cooldowns.clear()
+        combat_instance.retreat(self.char1, self.target)
+        self.call(
+            combat.CmdShoot(),
+            "rat",
+            "You shoot rat with your weapon",
+        )
+
+    def test_flee(self):
+        combat_instance = CombatHandler(self.char1, self.target)
+        self.call(
+            combat.CmdFlee(),
+            "",
+            "You flee!",
+        )
+        self.assertFalse(self.char1.nattributes.has("combat"))
+        self.assertFalse(self.target.nattributes.has("combat"))
+        self.assertEqual(self.char1.location, self.room2)

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -164,6 +164,9 @@ class WeaponEmptyHand:
     def __repr__(self):
         return "<WeaponEmptyHand>"
 
+    def get_display_name(self, *args, **kwargs):
+        """A dummy implementation of the hook, to smooth over combat messages."""
+        return self.key
 
 class WeaponObject(Object):
     """

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -11,7 +11,7 @@ from evennia import AttributeProperty
 from evennia.objects.objects import DefaultObject
 from evennia.utils.utils import make_iter
 
-from world.enums import Ability, ObjType, WieldLocation
+from world.enums import Ability, CombatRange, ObjType, WieldLocation
 from world.utils import get_obj_stats
 
 
@@ -159,6 +159,7 @@ class WeaponEmptyHand:
     defense_type = Ability.ARMOR
     damage_roll = "1d4"
     quality = 100000  # let's assume fists are always available ...
+    attack_range = CombatRange.MELEE
 
     def __repr__(self):
         return "<WeaponEmptyHand>"
@@ -174,6 +175,8 @@ class WeaponObject(Object):
     inventory_use_slot = AttributeProperty(WieldLocation.WEAPON_HAND)
     quality = AttributeProperty(3)
 
+    # maximum attack range for this weapon
+    attack_range = AttributeProperty(CombatRange.MELEE)
     # what ability used to attack with this weapon
     attack_type = AttributeProperty(Ability.STR)
     # what defense stat of the enemy it must defeat

--- a/world/combat.py
+++ b/world/combat.py
@@ -30,7 +30,7 @@ class CombatHandler:
             self.positions.pop(participant)
             participant.nattributes.remove("combat")
 
-            survivors = self.positions.keys()
+            survivors = list(self.positions.keys())
             if len(survivors) == 1:
                 # only one participant means no more fight
                 survivors[0].nattributes.remove("combat")

--- a/world/combat.py
+++ b/world/combat.py
@@ -1,0 +1,125 @@
+
+# maximum range for different weapon types
+_WEAPON_RANGES = {
+    "grapple": 0,
+    "melee": 1,
+    "reach": 2,
+    "ranged": 6,
+}
+
+# format for combat prompt, currently unused
+# health, mana, current attack cooldown
+COMBAT_PROMPT = "HP {hp} - MP {mp} - ACD {cd}"
+
+class CombatHandler:
+    positions = None
+    
+    def __init__(self, attacker, target):
+        # the starting position logic could be better
+        positions = { attacker: 1, target: 2 }
+        attacker.ndb.combat = self
+        target.ndb.combat = self
+    
+    def add(self, participant):
+        """Add a new combatant to the combat instance."""
+        # only add if they aren't already part of the fight
+        if participant not in self.positions:
+          positions[participant] = 0
+          participant.ndb.combat = self
+    
+    def remove(self, participant):
+        """Removes a combatant from the combat instance."""
+        # only remove if they're actually in combat
+        if participant in self.positions:
+            self.positions.pop(participant)
+            participant.nattributes.remove("combat")
+
+            survivors = self.positions.keys()
+            if len(survivors) == 1:
+                # only one participant means no more fight
+                survivors[0].nattributes.remove("combat")
+                self.positions = None
+  
+    def merge(self, other):
+        """Merge another combat instance into this one"""
+        # an entity can't be in two combat instances at once, so there should be no dupes
+        self.positions |= other.positions
+        for obj in other.positions.keys():
+            obj.ndb.combat = self
+        other.positions = None
+
+    def get_range(self, attacker, target):
+        """Get the distance from target in terms of weapon range."""
+        # both combatants must be in combat
+        if not (attacker in self.positions and target in self.positions):
+            return None
+
+        distance = abs(self.positions[attacker] - self.positions[target])
+        range = None
+        for key, val in _WEAPON_RANGES.items():
+            if val > distance:
+                break
+            range = key
+
+        return range
+
+    def in_range(self, attacker, target, range):
+        """Check if target is within the specified range of attacker."""
+        # both combatants must be in combat
+        if not (attacker in self.positions and target in self.positions):
+            return None
+        
+        if range not in _WEAPON_RANGES:
+            return False
+
+        distance = abs(self.positions[attacker] - self.positions[target])
+        return _WEAPON_RANGES[range] >= distance
+    
+    def any_in_range(self, attacker, range):
+        if attacker not in self.positions:
+            return False
+        
+        if range not in _WEAPON_RANGES:
+            return False
+        
+        return any( p for p in self.positions.values() if p <= _WEAPON_RANGES[range] )
+
+    def approach(self, mover, target):
+        """
+        Move a combatant towards the target.
+        Returns True if the distance changed, or False if it didn't.
+        """
+        # both combatants must be in combat
+        if not (mover in self.positions and target in self.positions):
+            return False
+
+        start = self.positions[mover]
+        end = self.positions[target]
+        
+        if start == end:
+            # already as close as you can get
+            return False
+        
+        change = 1 if start < end else -1
+        self.positions[mover] += change
+        return True
+
+    def retreat(self, mover, target):
+        """
+        Move a combatant away from the target.
+        Returns True if the distance changed, or False if it didn't.
+        """
+        # both combatants must be in combat
+        if not (mover in self.positions and target in self.positions):
+            return False
+
+        start = self.positions[mover]
+        end = self.positions[target]
+        
+        # can't move beyond maximum weapon range
+        if abs(start-end) >= max(_WEAPON_RANGES.values()):
+            return False
+
+        change = -1 if start < end else 1
+        self.positions[mover] += change
+        return True

--- a/world/enums.py
+++ b/world/enums.py
@@ -70,3 +70,13 @@ class ObjType(Enum):
     MAGIC = "magic"
     QUEST = "quest"
     TREASURE = "treasure"
+
+
+class CombatRange(Enum):
+    """
+    Maximum combat range values
+    """
+    GRAPPLE = 0
+    MELEE   = 1
+    REACH   = 2
+    RANGED  = 6


### PR DESCRIPTION
This uses an instanced combat handler and the cooldowns contrib to manage combat mechanics.

Adds:
- Melee and ranged combat instances
- Engage/flee, hit/shoot, advance/retreat commands
- Moving to a different room on successful `flee`
- Very basic death acknowledgement
- Preventing attacking players outside of PvP zones

Does NOT add:
- To-hit or damage mechanics
- Weapon prototypes
- Preventing exit traversal while in combat
- Actual death mechanics