### PR TITLE
Link Overworld to riverport

### DIFF
--- a/server/conf/at_initial_setup.py
+++ b/server/conf/at_initial_setup.py
@@ -14,8 +14,12 @@ does what you expect it to.
 
 """
 from django.conf import settings
+
 from evennia.contrib.grid.xyzgrid.launchcmd import xyzcommand
 from evennia.contrib.grid.xyzgrid.xyzgrid import get_xyzgrid
+from evennia.utils.create import create_object
+from evennia.utils.search import search_object_by_tag
+
 
 def at_initial_setup():
     maps_list = settings.XYZGRID_MAP_LIST
@@ -29,3 +33,13 @@ def at_initial_setup():
 
     grid.log = _log
     grid.spawn(xyz=("*", "*", "*"))
+
+
+    # Create Exits to Static Areas leading to the Overworld
+    exit_rooms = search_object_by_tag(key='area_exit', category='area_def')
+    for exit_room in exit_rooms:
+        create_object(
+            typeclass="typeclasses.exits.OverworldEntrance",
+            key="leave",
+            location=exit_room,
+        )

--- a/world/chargen.py
+++ b/world/chargen.py
@@ -7,6 +7,7 @@ import random
 from django.conf import settings
 
 from evennia import create_object, logger
+from evennia.contrib.grid.xyzgrid.xyzgrid import get_xyzgrid
 from evennia.objects.models import ObjectDB
 from evennia.prototypes.spawner import spawn
 from evennia.utils.evmenu import EvMenu
@@ -172,7 +173,13 @@ class TemporaryCharacterSheet:
         Once the chargen is complete, call this create and set up the character.
 
         """
-        start_location = ObjectDB.objects.get_id(settings.START_LOCATION)
+        grid = get_xyzgrid()
+        start_location = grid.get_room(('13', '8', 'riverport'))
+        if start_location:
+            start_location = start_location[0] # The room we got above is a queryset so we get it by index
+        else:
+            start_location = ObjectDB.objects.get_id(settings.START_LOCATION)
+
         default_home = ObjectDB.objects.get_id(settings.DEFAULT_HOME)
         permissions = settings.PERMISSION_ACCOUNT_DEFAULT
         # creating character with given abilities

--- a/world/maps/riverport.py
+++ b/world/maps/riverport.py
@@ -4,7 +4,7 @@ from evennia.contrib.grid.xyzgrid import xymap_legend
 class Intersection(xymap_legend.MapNode):
     display_symbol = "o"
     prototype = {
-            "prototype_parent": "ainneve_xyz_room",
+            "prototype_parent": "riverport_xyz_room",
             "key": "An intersection",
             "desc": "An intersection of Riverport roads."
         }
@@ -12,7 +12,7 @@ class Intersection(xymap_legend.MapNode):
 class RoadNode(xymap_legend.MapNode):
     display_symbol = "o"
     prototype = {
-            "prototype_parent": "ainneve_xyz_room",
+            "prototype_parent": "riverport_xyz_room",
             "key": "A road",
             "desc": "A road through Riverport."
         }
@@ -21,15 +21,16 @@ class GateNode(xymap_legend.MapNode):
     # Note: these nodes will need to be manually connected to the overworld
     display_symbol = "#"
     prototype = {
-            "prototype_parent": "ainneve_xyz_room",
+            "prototype_parent": "riverport_xyz_room",
             "key": "A gate",
-            "desc": "A gateway set into the walls of Riverport."
+            "desc": "A gateway set into the walls of Riverport.",
+            "tags": [('area_exit', 'area_def')],
         }
 
 class HouseNode(xymap_legend.MapNode):
     display_symbol = "∆"
     prototype = {
-            "prototype_parent": "ainneve_xyz_room",
+            "prototype_parent": "riverport_xyz_room",
             "key": "Inside",
             "desc": "A building inside Riverport."
         }
@@ -39,7 +40,7 @@ class HouseNode(xymap_legend.MapNode):
 class BridgeNode(xymap_legend.MapNode):
     display_symbol = "Ξ"
     prototype = {
-            "prototype_parent": "ainneve_xyz_room",
+            "prototype_parent": "riverport_xyz_room",
             "key": "A bridge",
             "desc": "A bridge over the river."
         }
@@ -65,7 +66,7 @@ LEGEND = {
 
 PROTOTYPES = {
     (13, 8): {
-        "prototype_parent": "ainneve_xyz_room",
+        "prototype_parent": "riverport_xyz_room",
         "key": "A fountain",
         "desc": "A fountain in the center of Riverport.",
     },

--- a/world/overworld/landmarks.py
+++ b/world/overworld/landmarks.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class Landmark:
+    key: str
     name: str
     coordinates: tuple[int, int]
     room_prototype: str
@@ -20,20 +21,23 @@ class OverworldLandmarks:
     _cached_dict = None
 
     Whiterock_Kingdom = Landmark(
+        key="whiterock_kingdom",
         name="Whiterock Kingdom",
         coordinates=(11, 23),
         room_prototype="wilderness_landmark_whiterock_kingdom",
-        area_exit_prototype="wilderness_exit_to_whiterock_kingdom"
+        area_exit_prototype="wilderness_exit_to_whiterock_kingdom",
     )
 
     Tobichi_Forest = Landmark(
+        key="tobichi_forest",
         name="Tobichi Forest",
         coordinates=(44, 18),
         room_prototype="wilderness_landmark_tobichi_forest",
-        area_exit_prototype="wilderness_exit_to_tobichi_forest"
+        area_exit_prototype="wilderness_exit_to_tobichi_forest",
     )
 
     Furrato_Valley = Landmark(
+        key="furrato_valley",
         name="Furrato Valley",
         coordinates=(21, 20),
         room_prototype="wilderness_landmark_furrato_valley",
@@ -41,13 +45,15 @@ class OverworldLandmarks:
     )
 
     Riverport_Settlement = Landmark(
+        key="riverport_settlement",
         name="Riverport Settlement",
-        coordinates=(41, 31),
-        room_prototype="wilderness_landmark_riverport_settlement",
+        coordinates=(41, 35),
+        room_prototype="landmark_riverport_room",
         area_exit_prototype="wilderness_exit_to_riverport_settlement",
     )
 
     Selonna_Bay = Landmark(
+        key="selonna_bay",
         name="Selonna Bay",
         coordinates=(64, 28),
         room_prototype="wilderness_landmark_selonna_bay",
@@ -55,6 +61,7 @@ class OverworldLandmarks:
     )
 
     Renegade_Hideout = Landmark(
+        key="renegade_hideout",
         name="Renegade's Hideout",
         coordinates=(7, 22),
         room_prototype="wilderness_landmark_renegade_hideout",
@@ -62,6 +69,7 @@ class OverworldLandmarks:
     )
 
     Smuggler_Cove = Landmark(
+        key="smugglers_cove",
         name="Smuggler's Cove",
         coordinates=(42, 3),
         room_prototype="wilderness_landmark_smuggler_cove",
@@ -69,6 +77,7 @@ class OverworldLandmarks:
     )
 
     Taurosu_Tribe = Landmark(
+        key="taurosu_tribe",
         name="Taurosu Tribe",
         coordinates=(55, 45),
         room_prototype="wilderness_landmark_taurosu_tribe",
@@ -76,6 +85,7 @@ class OverworldLandmarks:
     )
 
     Tomu_Lake = Landmark(
+        key="tomu_lake",
         name="Tomu Lake",
         coordinates=(21, 14),
         room_prototype="wilderness_landmark_tomu_lake",
@@ -83,6 +93,7 @@ class OverworldLandmarks:
     )
 
     Goldgrass_Plains = Landmark(
+        key="goldgrass_plains",
         name="Goldgrass Plains",
         coordinates=(56, 48),
         room_prototype="wilderness_landmark_goldgrass_plains",
@@ -90,6 +101,7 @@ class OverworldLandmarks:
     )
 
     Soran_Castle = Landmark(
+        key="soran_castle",
         name="Soran Castle",
         coordinates=(32, 4),
         room_prototype="wilderness_landmark_soran_castle",
@@ -97,6 +109,7 @@ class OverworldLandmarks:
     )
 
     Cactus_Canyon = Landmark(
+        key="cactus_canyon",
         name="Cactus Canyon",
         coordinates=(18, 42),
         room_prototype="wilderness_landmark_cactus_canyon",
@@ -104,6 +117,7 @@ class OverworldLandmarks:
     )
 
     Litchbane_Keep = Landmark(
+        key="litchbane_keep",
         name="Litchbane Keep",
         coordinates=(11, 54),
         room_prototype="wilderness_landmark_litchbane_keep",
@@ -111,6 +125,7 @@ class OverworldLandmarks:
     )
 
     Yaban_Hinterlands = Landmark(
+        key="yaban_hinterlands",
         name="Yaban Hinterlands",
         coordinates=(18, 42),
         room_prototype="wilderness_landmark_yaban_hinterlands",
@@ -118,6 +133,7 @@ class OverworldLandmarks:
     )
 
     Sun_Temple = Landmark(
+        key="sun_temple",
         name="Sun Temple",
         coordinates=(38, 6),
         room_prototype="wilderness_landmark_sun_temple",
@@ -125,6 +141,7 @@ class OverworldLandmarks:
     )
 
     Moon_Temple = Landmark(
+        key="moon_temple",
         name="Moon Temple",
         coordinates=(51, 45),
         room_prototype="wilderness_landmark_moon_temple",
@@ -132,6 +149,7 @@ class OverworldLandmarks:
     )
 
     Earth_Temple = Landmark(
+        key="earth_temple",
         name="Earth Temple",
         coordinates=(12, 56),
         room_prototype="wilderness_landmark_earth_temple",
@@ -139,6 +157,7 @@ class OverworldLandmarks:
     )
 
     Star_Temple = Landmark(
+        key="star_temple",
         name="Star Temple",
         coordinates=(68, 14),
         room_prototype="wilderness_landmark_star_temple",
@@ -146,6 +165,7 @@ class OverworldLandmarks:
     )
 
     Aether_Temple = Landmark(
+        key="aether_temple",
         name="Aether Temple",
         coordinates=(12, 56),
         room_prototype="wilderness_landmark_aether_temple",
@@ -153,6 +173,7 @@ class OverworldLandmarks:
     )
 
     Zeita_Palace = Landmark(
+        key="zeita_palace",
         name="Zeita Palace",
         coordinates=(11, 63),
         room_prototype="wilderness_landmark_zeita_palace",
@@ -160,6 +181,7 @@ class OverworldLandmarks:
     )
 
     Sarab_Oasis = Landmark(
+        key="scarab_oasis",
         name="Sarab Oasis",
         coordinates=(21, 41),
         room_prototype="wilderness_landmark_sarab_oasis",
@@ -167,6 +189,7 @@ class OverworldLandmarks:
     )
 
     Aiiro_Lake = Landmark(
+        key="aiiro_lake",
         name="Aiiro Lake",
         coordinates=(42, 35),
         room_prototype="wilderness_landmark_aiiro_lake",
@@ -174,6 +197,7 @@ class OverworldLandmarks:
     )
 
     Centaurian_Herdclan = Landmark(
+        key="centaurian_herdclan",
         name="Centaurian 'Brownhoof' Herdclan",
         coordinates=(56, 24),
         room_prototype="wilderness_landmark_centaurian_herdclan",
@@ -181,6 +205,7 @@ class OverworldLandmarks:
     )
 
     Acidmire_Marsh = Landmark(
+        key="acidmire_marsh",
         name="Acidmire Marsh",
         coordinates=(44, 10),
         room_prototype="wilderness_landmark_acidmire_marsh",
@@ -188,6 +213,7 @@ class OverworldLandmarks:
     )
 
     Aetherfen_Swamp = Landmark(
+        key="aetherfen_swamp",
         name="Aetherfen Swamp",
         coordinates=(15, 55),
         room_prototype="wilderness_landmark_aetherfen_swamp",
@@ -195,6 +221,7 @@ class OverworldLandmarks:
     )
 
     Highborn_Settlement = Landmark(
+        key="highborn_settlement",
         name="Highborn Settlement",
         coordinates=(27, 11),
         room_prototype="wilderness_landmark_highborn_settlement",
@@ -204,7 +231,7 @@ class OverworldLandmarks:
     @classmethod
     def _get_cached_dict(cls):
         if not cls._cached_dict:
-            new_dict = {key: value for key, value in cls.__dict__.items() if isinstance(value, Landmark)}
+            new_dict = {value.key: value for value in cls.__dict__.values() if isinstance(value, Landmark)}
             cls._cached_dict = new_dict
 
         return cls._cached_dict
@@ -216,3 +243,14 @@ class OverworldLandmarks:
     @classmethod
     def values(cls):
         return cls._get_cached_dict().values()
+
+    @classmethod
+    def get(cls, key):
+        return cls._get_cached_dict().get(key)
+
+    @classmethod
+    def get_by_coordinates(cls, coordinates):
+        return next(
+            (val for val in cls._get_cached_dict().values()
+             if val.coordinates == coordinates), None
+        )

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -10,6 +10,18 @@ AINNEVE_XYZ_ROOM = {
         "typeclass": "typeclasses.rooms.TownRoom",
     }
 
+RIVERPORT_XYZ_ROOM = {
+        "prototype_parent": "ainneve_xyz_room",
+        "prototype_key": "riverport_xyz_room",
+        "typeclass": "typeclasses.rooms.TownRoom",
+        "tags": [('riverport_settlement', 'area_id')]
+    }
+
+
+LANDMARK_RIVERPORT_ROOM = {
+    "prototype_key": "landmark_riverport_room",
+    "desc": "You are standing in front of the city gates.",
+}
 
 
 


### PR DESCRIPTION
This allows walking from Riverport to the Overworld and back.
Going forward, each area should be properly tagged (area_key, 'area_id') and each area exit that should lead to the overworld should be tagged ('area_exit', 'area_def') so that they will be automatically linked.

It will also set a proper starting location for new characters, the fountain in Riveport.
Note that there's a contrib bug that prevents going back in Riverport that needs to be fixed before merging.