### PR TITLE
Load docstring for WieldOrWear into two help files

### DIFF
--- a/commands/game.py
+++ b/commands/game.py
@@ -101,6 +101,7 @@ class CmdWieldOrWear(Command):
 
     key = "wield"
     aliases = ("wear",)
+    auto_help = False
 
     out_txts = {
         WieldLocation.BACKPACK: "You shuffle the position of {key} around in your backpack.",

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -40,6 +40,9 @@ AUTO_CREATE_CHARACTER_WITH_ACCOUNT = False
 AUTO_PUPPET_ON_LOGIN = False
 MAX_NR_CHARACTERS = 5
 
+FILE_HELP_ENTRY_MODULES = [ 'world.help.combat_help' ]
+
+
 ######################################################################
 # XYZ Grid install settings
 ######################################################################

--- a/world/help/combat_help.py
+++ b/world/help/combat_help.py
@@ -1,0 +1,14 @@
+from commands.game import CmdWieldOrWear
+
+HELP_ENTRY_DICTS = [
+  {
+    "key": "wear",
+    "category": "Combat",
+    "text": CmdWieldOrWear.__doc__
+  },
+  {
+    "key": "wield",
+    "category": "Combat",
+    "text": CmdWieldOrWear.__doc__
+  },
+]


### PR DESCRIPTION
References the same docstring for custom module help keys, "wield" and "wear", to maintain ease of updating while making it clearer how to equip gear from the help list.